### PR TITLE
Add parseCredentialStatus utility and StatusClaim type

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,9 +163,7 @@ addCommonOptions(testIssuance);
 
 testIssuance.action((options) => {
   const env = setEnvFromOptions(options);
-  const tests = env.TESTS?.
-    split(/\s*,\s*/g).
-    filter(i => i.length > 0) ?? [];
+  const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
 
   try {
     execFileSync("pnpm", ["test:issuance", ...tests], {
@@ -186,9 +184,7 @@ addCommonOptions(testPresentation);
 
 testPresentation.action((options) => {
   const env = setEnvFromOptions(options);
-  const tests = env.TESTS?.
-    split(/\s*,\s*/g).
-    filter(i => i.length > 0) ?? [];
+  const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
 
   try {
     execFileSync("pnpm", ["test:issuance", ...tests], {

--- a/src/functions/V1_0/mock-credentials.ts
+++ b/src/functions/V1_0/mock-credentials.ts
@@ -2,7 +2,7 @@ import { DataItem, Document } from "@auth0/mdl";
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { digest, ES256, generateSalt } from "@sd-jwt/crypto-nodejs";
 import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-import { encode, Tagged } from "cbor";
+import { decode, encode, Tagged } from "cbor";
 import { decodeJwt } from "jose";
 
 import {
@@ -71,6 +71,22 @@ export async function buildMockMdlMdoc_V1_0(
     });
 
   const issuerSigned = document.prepare().get("issuerSigned");
+  const payloadWithStatus = encode(
+    new Tagged(
+      24,
+      encode({
+        ...decode(decode(issuerSigned.issuerAuth[2]).value),
+        status: {
+          status_assertion: {
+            credential_hash_alg: "sha-256",
+          },
+        },
+      }),
+    ),
+  );
+  issuerSigned.issuerAuth[2] = payloadWithStatus;
+  const parsed = document as any;
+  parsed.issuerSigned.issuerAuth.payload = payloadWithStatus;
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<
@@ -91,7 +107,7 @@ export async function buildMockMdlMdoc_V1_0(
 
   return {
     compact,
-    parsed: document,
+    parsed,
     typ: "mso_mdoc",
   };
 }

--- a/src/functions/V1_3/mock-credentials.ts
+++ b/src/functions/V1_3/mock-credentials.ts
@@ -2,7 +2,7 @@ import { DataItem, Document } from "@auth0/mdl";
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { digest, ES256, generateSalt } from "@sd-jwt/crypto-nodejs";
 import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-import { encode, Tagged } from "cbor";
+import { decode, encode, Tagged } from "cbor";
 import { decodeJwt } from "jose";
 
 import {
@@ -78,6 +78,23 @@ export async function buildMockMdlMdoc_V1_3(
     });
 
   const issuerSigned = document.prepare().get("issuerSigned");
+  const payloadWithStatus = encode(
+    new Tagged(
+      24,
+      encode({
+        ...decode(decode(issuerSigned.issuerAuth[2]).value),
+        status: {
+          status_list: {
+            idx: 0,
+            uri: "https://example.com",
+          },
+        },
+      }),
+    ),
+  );
+  issuerSigned.issuerAuth[2] = payloadWithStatus;
+  const parsed = document as any;
+  parsed.issuerSigned.issuerAuth.payload = payloadWithStatus;
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<

--- a/src/functions/V1_3/mock-credentials.ts
+++ b/src/functions/V1_3/mock-credentials.ts
@@ -55,6 +55,7 @@ export async function buildMockMdlMdoc_V1_3(
   deviceKey: KeyPairJwk,
   issuerCertificate: string,
   issuerKeyPair: KeyPair,
+  issuerBaseUrl: string,
 ): Promise<Credential> {
   const claims = loadJsonDumps(
     "mDL.json",
@@ -86,7 +87,7 @@ export async function buildMockMdlMdoc_V1_3(
         status: {
           status_list: {
             idx: 0,
-            uri: "https://example.com",
+            uri: `${issuerBaseUrl}/status-list`,
           },
         },
       }),

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -1,11 +1,18 @@
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { SDJwt } from "@sd-jwt/core";
 import { digest } from "@sd-jwt/crypto-nodejs";
+import { decode } from "cbor";
 import { readdirSync, readFileSync } from "node:fs";
 
 import { buildJwksPath, ensureDir, loadJwks, parseMdoc } from "@/logic";
 import { getLocalCiBaseUrl } from "@/servers/ci-server";
-import { Config, Credential, CredentialWithKey, Logger } from "@/types";
+import {
+  Config,
+  Credential,
+  CredentialWithKey,
+  Logger,
+  StatusClaim,
+} from "@/types";
 
 import {
   createMockMdlMdoc,
@@ -124,6 +131,35 @@ export async function loadCredentialsForPresentation(
   );
 }
 
+export async function parseCredentialStatus(
+  compact: string,
+): Promise<null | StatusClaim> {
+  const parsed = await parseCredential(compact);
+
+  const { credential } = parsed;
+  if (!credential)
+    throw new Error(
+      "unable to unmarshal string into sd-jwt or mdoc credential",
+    );
+
+  switch (credential.typ) {
+    case "dc+sd-jwt":
+      const sdJwtPayload = credential.parsed.payload;
+      if (!sdJwtPayload) throw new Error("parsed sd-jwt has empty payload");
+
+      return sdJwtPayload.status as StatusClaim;
+    case "mso_mdoc":
+      const mdocPayloadTag = decode(
+        credential.parsed.issuerSigned.issuerAuth.payload,
+      );
+      const mdocPayload = decode(mdocPayloadTag.value);
+
+      return mdocPayload.status as StatusClaim;
+    default:
+      return null;
+  }
+}
+
 /**
  * Creates mock SD-JWT and MDOC credentials when no stored credentials are available.
  * Persists the generated credentials and their key pairs to the configured storage paths.
@@ -167,6 +203,27 @@ async function createMockCredentialsWithKeys(
     ),
   ]);
 }
+async function parseCredential(
+  compact: string,
+): Promise<{ credential?: Credential; error?: string }> {
+  let error: null | string = null;
+
+  try {
+    const parsed = await SDJwt.decodeSDJwt(compact, digest);
+    return { credential: { compact, parsed, typ: "dc+sd-jwt" } };
+  } catch (e) {
+    error = `Local credential was not a valid sd-jwt credential: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  try {
+    const parsed = parseMdoc(Buffer.from(compact, "base64url"));
+    return { credential: { compact, parsed, typ: "mso_mdoc" }, error };
+  } catch (e) {
+    return {
+      error: `Local credential was not a valid mdoc credential: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
 
 /**
  * Attempts to parse a credential file as SD-JWT first, then as MDOC.
@@ -192,23 +249,10 @@ async function parseCredentialFile(
     return null;
   }
 
-  try {
-    const parsed = await SDJwt.decodeSDJwt(compact, digest);
-    return { compact, parsed, typ: "dc+sd-jwt" };
-  } catch (e) {
-    onIgnoreError(
-      `Local credential '${fileName}' was not a valid sd-jwt credential: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
+  const parsed = await parseCredential(compact);
+  if (parsed.error) onIgnoreError(`${fileName}: ${parsed.error}`);
 
-  try {
-    const parsed = parseMdoc(Buffer.from(compact, "base64url"));
-    return { compact, parsed, typ: "mso_mdoc" };
-  } catch (e) {
-    onIgnoreError(
-      `Local credential '${fileName}' was not a valid mdoc credential: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
+  if (parsed.credential) return parsed.credential;
 
   return null;
 }

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -131,6 +131,13 @@ export async function loadCredentialsForPresentation(
   );
 }
 
+/**
+ * Parses a credential and extracts its status claim.
+ *
+ * @param compact - The compact-serialized credential string.
+ * @returns A promise that resolves to the `StatusClaim` if present, or `null` if the format is unsupported or status is missing.
+ * @throws {Error} If the credential cannot be parsed or has an empty payload.
+ */
 export async function parseCredentialStatus(
   compact: string,
 ): Promise<null | StatusClaim> {
@@ -203,6 +210,13 @@ async function createMockCredentialsWithKeys(
     ),
   ]);
 }
+
+/**
+ * Attempts to parse a compact-serialized credential as either SD-JWT or MDOC.
+ *
+ * @param compact - The compact-serialized credential string.
+ * @returns A promise resolving to an object containing either the parsed `Credential` or an error message.
+ */
 async function parseCredential(
   compact: string,
 ): Promise<{ credential?: Credential; error?: string }> {

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -108,6 +108,7 @@ export async function loadCredentialsForPresentation(
           : createMockMdlMdoc(
               config.issuance.certificate_subject ??
                 `CN=${config.issuance.url}`,
+              getLocalCiBaseUrl(config.issuer.port),
               config.wallet.backup_storage_path,
               config.wallet.credentials_storage_path,
               config.wallet.wallet_version,
@@ -204,6 +205,7 @@ async function createMockCredentialsWithKeys(
   );
   const mobileDriverLicence = await createMockMdlMdoc(
     config.issuance.certificate_subject ?? `CN=${config.issuance.url}`,
+    getLocalCiBaseUrl(config.issuer.port),
     config.wallet.backup_storage_path,
     config.wallet.credentials_storage_path,
     config.wallet.wallet_version,

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -151,15 +151,29 @@ export async function parseCredentialStatus(
 
   switch (credential.typ) {
     case "dc+sd-jwt":
-      const sdJwtPayload = credential.parsed.payload;
-      if (!sdJwtPayload) throw new Error("parsed sd-jwt has empty payload");
+      const sdJwtPayload = credential.parsed.jwt.payload;
+      if (!sdJwtPayload || typeof sdJwtPayload !== "object")
+        throw new Error("parsed sd-jwt has empty or malformed payload");
+
+      if (!sdJwtPayload.status) return null;
 
       return sdJwtPayload.status as StatusClaim;
     case "mso_mdoc":
       const mdocPayloadTag = decode(
         credential.parsed.issuerSigned.issuerAuth.payload,
       );
+      if (
+        !mdocPayloadTag.value ||
+        !mdocPayloadTag.tag ||
+        mdocPayloadTag.tag !== 24
+      )
+        throw new Error("could not extract payload from mdoc");
+
       const mdocPayload = decode(mdocPayloadTag.value);
+      if (typeof mdocPayload !== "object")
+        throw new Error("parsed mdoc has malformed payload");
+
+      if (!mdocPayload.status) return null;
 
       return mdocPayload.status as StatusClaim;
     default:

--- a/src/functions/mock-credentials.ts
+++ b/src/functions/mock-credentials.ts
@@ -34,6 +34,7 @@ import {
 
 export async function createMockMdlMdoc(
   subject: string,
+  issuerBaseUrl: string,
   backupPath: string,
   credentialsPath: string,
   version: ItWalletSpecsVersion,
@@ -69,6 +70,7 @@ export async function createMockMdlMdoc(
         deviceKey,
         issuerCertificate,
         issuerKeyPair,
+        issuerBaseUrl,
       );
       break;
     default:

--- a/src/types/credential.ts
+++ b/src/types/credential.ts
@@ -33,6 +33,21 @@ export type DcqlMatchSuccess = Extract<
   { success: true }
 >;
 
+export interface StatusClaimV1_0 {
+  status_assertion: {
+    credential_hash_alg: string,
+  },
+}
+
+export interface StatusClaimV1_3 {
+  status_list: {
+    idx: number,
+    uri: string,
+  },
+}
+
+export type StatusClaim = StatusClaimV1_0 | StatusClaimV1_3;
+
 export interface VpTokenOptions {
   client_id: string;
   credential: string;

--- a/src/types/credential.ts
+++ b/src/types/credential.ts
@@ -33,20 +33,20 @@ export type DcqlMatchSuccess = Extract<
   { success: true }
 >;
 
+export type StatusClaim = StatusClaimV1_0 | StatusClaimV1_3;
+
 export interface StatusClaimV1_0 {
   status_assertion: {
-    credential_hash_alg: string,
-  },
+    credential_hash_alg: string;
+  };
 }
 
 export interface StatusClaimV1_3 {
   status_list: {
-    idx: number,
-    uri: string,
-  },
+    idx: number;
+    uri: string;
+  };
 }
-
-export type StatusClaim = StatusClaimV1_0 | StatusClaimV1_3;
 
 export interface VpTokenOptions {
   client_id: string;

--- a/tests/conformance/issuance/token-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/token-validation.issuance.spec.ts
@@ -232,6 +232,7 @@ testConfigs.forEach((testConfig) => {
 
     test(
       "CI_061: Authorization Code Validity | Issuer rejects reused code (invalid_grant)",
+      { timeout: 5e3 },
       async () => {
         const log = baseLog.withTag("CI_061");
         const DESCRIPTION = "Issuer correctly rejectedd reused code";
@@ -270,7 +271,6 @@ testConfigs.forEach((testConfig) => {
           log.testCompleted(DESCRIPTION, testSuccess);
         }
       },
-      { timeout: 5e3 },
     );
   });
 });

--- a/tests/conformance/issuance/token-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/token-validation.issuance.spec.ts
@@ -232,7 +232,7 @@ testConfigs.forEach((testConfig) => {
 
     test(
       "CI_061: Authorization Code Validity | Issuer rejects reused code (invalid_grant)",
-      { timeout: 5e3 },
+      { timeout: 6e3 },
       async () => {
         const log = baseLog.withTag("CI_061");
         const DESCRIPTION = "Issuer correctly rejectedd reused code";

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -692,7 +692,7 @@ describe("Parse Credential's Status", () => {
     expect(status).toEqual({
       status_list: {
         idx: 0,
-        uri: "https://example.com",
+        uri: `${metadata.iss}/status-list`,
       },
     });
   });

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -40,6 +40,7 @@ import { KeyPairJwk, zTrustChain, zX5c } from "@/types";
 
 const backupDir = "./tests/mocked-data/backup";
 const credentialsDir = "./tests/mocked-data/credentials";
+const iss = "https://issuer.example.com";
 
 describe("Load Mocked Credentials", async () => {
   const config = loadConfig("./config.ini");
@@ -501,7 +502,6 @@ describe("Load Mocked Credentials", async () => {
 
 describe("Generate Mocked Credentials", () => {
   const config = loadConfig("./config.ini");
-  const iss = "https://issuer.example.com";
   const metadata = {
     iss,
     network: config.network,
@@ -623,7 +623,7 @@ describe("Generate Mocked Credentials", () => {
     async (version) => {
       const credential = await createMockMdlMdoc(
         "CN=test_issuer",
-        "https://issuer.example.com",
+        iss,
         backupDir,
         backupDir,
         version,
@@ -660,7 +660,7 @@ describe("Parse Credential's Status", () => {
 
   const config = loadConfig("./config.ini");
   const metadata = {
-    iss: "https://issuer.example.com",
+    iss,
     network: config.network,
     trust: config.trust,
     trustAnchor: config.trust_anchor,
@@ -701,7 +701,7 @@ describe("Parse Credential's Status", () => {
   it("should retrieve status from MDOC (V1_0)", async () => {
     const credential = await createMockMdlMdoc(
       "CN=test_issuer",
-      "https://issuer.example.com",
+      iss,
       backupDir,
       backupDir,
       ItWalletSpecsVersion.V1_0,
@@ -717,7 +717,7 @@ describe("Parse Credential's Status", () => {
   it("should retrieve status from MDOC (V1_3)", async () => {
     const credential = await createMockMdlMdoc(
       "CN=test_issuer",
-      "https://issuer.example.com",
+      iss,
       backupDir,
       backupDir,
       ItWalletSpecsVersion.V1_3,
@@ -726,7 +726,7 @@ describe("Parse Credential's Status", () => {
     expect(status).toEqual({
       status_list: {
         idx: 0,
-        uri: "https://example.com",
+        uri: `${iss}/status-list`,
       },
     });
   });

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -623,6 +623,7 @@ describe("Generate Mocked Credentials", () => {
     async (version) => {
       const credential = await createMockMdlMdoc(
         "CN=test_issuer",
+        "https://issuer.example.com",
         backupDir,
         backupDir,
         version,
@@ -700,6 +701,7 @@ describe("Parse Credential's Status", () => {
   it("should retrieve status from MDOC (V1_0)", async () => {
     const credential = await createMockMdlMdoc(
       "CN=test_issuer",
+      "https://issuer.example.com",
       backupDir,
       backupDir,
       ItWalletSpecsVersion.V1_0,
@@ -715,6 +717,7 @@ describe("Parse Credential's Status", () => {
   it("should retrieve status from MDOC (V1_3)", async () => {
     const credential = await createMockMdlMdoc(
       "CN=test_issuer",
+      "https://issuer.example.com",
       backupDir,
       backupDir,
       ItWalletSpecsVersion.V1_3,

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -16,14 +16,15 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 
 import {
   createMockMdlMdoc,
+  createMockSdJwt,
   getCredentialMdocExpiration,
   getCredentialSdJwtExpiration,
   isCredentialMdocExpired,
   isCredentialSdJwtExpired,
   loadCredentials,
   loadCredentialsForPresentation,
+  parseCredentialStatus,
 } from "@/functions";
-import { createMockSdJwt } from "@/functions";
 import {
   buildJwksPath,
   createKeys,
@@ -642,6 +643,96 @@ describe("Generate Mocked Credentials", () => {
       );
     },
   );
+});
+
+describe("Parse Credential's Status", () => {
+  afterAll(() => {
+    for (const version of ["V1_0", "V1_3"]) {
+      rmSync(`${backupDir}/${version}/dc_sd_jwt_PersonIdentificationData`, {
+        force: true,
+      });
+      rmSync(`${backupDir}/${version}/mso_mdoc_mDL`, {
+        force: true,
+      });
+    }
+  });
+
+  const config = loadConfig("./config.ini");
+  const metadata = {
+    iss: "https://issuer.example.com",
+    network: config.network,
+    trust: config.trust,
+    trustAnchor: config.trust_anchor,
+    trustAnchorBaseUrl: `https://127.0.0.1:${config.trust_anchor.port}`,
+  };
+
+  it("should retrieve status from SD-JWT (V1_0)", async () => {
+    const credential = await createMockSdJwt(
+      metadata,
+      backupDir,
+      backupDir,
+      ItWalletSpecsVersion.V1_0,
+    );
+    const status = await parseCredentialStatus(credential.compact);
+    expect(status).toEqual({
+      status_assertion: {
+        credential_hash_alg: "sha-256",
+      },
+    });
+  });
+
+  it("should retrieve status from SD-JWT (V1_3)", async () => {
+    const credential = await createMockSdJwt(
+      metadata,
+      backupDir,
+      backupDir,
+      ItWalletSpecsVersion.V1_3,
+    );
+    const status = await parseCredentialStatus(credential.compact);
+    expect(status).toEqual({
+      status_list: {
+        idx: 0,
+        uri: "https://example.com",
+      },
+    });
+  });
+
+  it("should retrieve status from MDOC (V1_0)", async () => {
+    const credential = await createMockMdlMdoc(
+      "CN=test_issuer",
+      backupDir,
+      backupDir,
+      ItWalletSpecsVersion.V1_0,
+    );
+    const status = await parseCredentialStatus(credential.compact);
+    expect(status).toEqual({
+      status_assertion: {
+        credential_hash_alg: "sha-256",
+      },
+    });
+  });
+
+  it("should retrieve status from MDOC (V1_3)", async () => {
+    const credential = await createMockMdlMdoc(
+      "CN=test_issuer",
+      backupDir,
+      backupDir,
+      ItWalletSpecsVersion.V1_3,
+    );
+    const status = await parseCredentialStatus(credential.compact);
+    expect(status).toEqual({
+      status_list: {
+        idx: 0,
+        uri: "https://example.com",
+      },
+    });
+  });
+
+  it("should throw error for invalid credential format", async () => {
+    await expect(parseCredentialStatus("invalid_data")).rejects.toThrow(
+      "unable to unmarshal string into sd-jwt or mdoc credential",
+    );
+  });
 });
 
 describe("createVpTokenMdoc", () => {


### PR DESCRIPTION
#### Motivation and Context

This change introduces a centralized utility for parsing and validating the status claim of credentials, supporting both SD-JWT and MDOC formats across IT Wallet specification versions V1.0 and V1.3. By implementing the `parseCredentialStatus` function and defining the `StatusClaim` union type, the system can now programmatically extract revocation or status information—whether it's located in the SD-JWT payload or CBOR-encoded within an MDOC's issuer-signed data. This infrastructure is essential for upcoming features that require real-time validation of a credential's validity during the issuance and presentation flows.

JIRA Ticket: WLEO-1006 WLEO-1093