### PR TITLE
Add notAfter to mock certificates and handle clock-skew in checks

### DIFF
--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -18,7 +18,7 @@ import {
   createFederationMetadata,
   createSubordinateTrustAnchorMetadata,
   ensureDir,
-  EXPIRY_LEEWAY_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   getTrustMarks,
   hasTrustChainExpired,
   loadJsonDumps,
@@ -236,7 +236,7 @@ export const loadAttestation = async (
       if (
         !exp ||
         typeof exp !== "number" ||
-        exp * 1000 < Date.now() - EXPIRY_LEEWAY_MS
+        exp * 1000 < Date.now() - CLOCK_SKEW_TOLERANCE_MS
       )
         throw new AttestationExpiredError("attestation expired");
       const trust_chain = zTrustChain.safeParse(

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -18,6 +18,7 @@ import {
   createFederationMetadata,
   createSubordinateTrustAnchorMetadata,
   ensureDir,
+  EXPIRY_LEEWAY_MS,
   getTrustMarks,
   hasTrustChainExpired,
   loadJsonDumps,
@@ -232,7 +233,11 @@ export const loadAttestation = async (
       // Since, at version 0.17.0, the SDJwt.extractJwt method dosn't check for WIA expiration,
       // it must be done manually
       const exp = attestationJwt.payload?.exp;
-      if (!exp || typeof exp !== "number" || exp * 1000 < Date.now())
+      if (
+        !exp ||
+        typeof exp !== "number" ||
+        exp * 1000 < Date.now() - EXPIRY_LEEWAY_MS
+      )
         throw new AttestationExpiredError("attestation expired");
       const trust_chain = zTrustChain.safeParse(
         attestationJwt.header?.trust_chain,

--- a/src/functions/mock-credentials.ts
+++ b/src/functions/mock-credentials.ts
@@ -10,6 +10,7 @@ import {
   buildCertPath,
   buildJwksPath,
   ensureDir,
+  EXPIRY_LEEWAY_MS,
   hasTrustChainExpired,
   hasX509CertificateExpired,
   loadCertificate,
@@ -281,14 +282,15 @@ export function isCredentialSdJwtExpired(
   const now = Date.now();
   const isCredentialExpired =
     claimName !== undefined &&
-    getCredentialSdJwtExpiration(parsed, claimName).getTime() < now;
+    getCredentialSdJwtExpiration(parsed, claimName).getTime() <
+      now - EXPIRY_LEEWAY_MS;
 
   const exp = parsed.jwt.payload?.exp;
   const isJwtExpired =
     checks.jwt &&
     exp !== undefined &&
     typeof exp === "number" &&
-    exp * 1000 < now;
+    exp * 1000 < now - EXPIRY_LEEWAY_MS;
 
   const jwt_trust_chain = zTrustChain.safeParse(parsed.jwt.header?.trust_chain);
   const isTrustChainExpired =

--- a/src/functions/mock-credentials.ts
+++ b/src/functions/mock-credentials.ts
@@ -10,11 +10,12 @@ import {
   buildCertPath,
   buildJwksPath,
   ensureDir,
-  EXPIRY_LEEWAY_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   hasTrustChainExpired,
   hasX509CertificateExpired,
   loadCertificate,
   loadJwks,
+  VALIDITY_MS,
 } from "@/logic";
 import {
   Config,
@@ -53,7 +54,7 @@ export async function createMockMdlMdoc(
     subject,
   );
 
-  const expiration = new Date(Date.now() + 24 * 60 * 60 * 1000 * 365);
+  const expiration = new Date(Date.now() + VALIDITY_MS);
   let mockedMdoc: Credential;
   switch (version) {
     case ItWalletSpecsVersion.V1_0:
@@ -112,7 +113,7 @@ export async function createMockSdJwt(
     "CN=test_issuer",
   );
 
-  const expiration = new Date(Date.now() + 24 * 60 * 60 * 1000 * 365);
+  const expiration = new Date(Date.now() + VALIDITY_MS);
   let mockedSdjwt: Credential;
   switch (version) {
     case ItWalletSpecsVersion.V1_0:
@@ -228,11 +229,13 @@ export function isCredentialMdocExpired(
   const now = Date.now();
   const isCredentialExpired =
     path !== undefined &&
-    getCredentialMdocExpiration(document, path).getTime() < now;
+    getCredentialMdocExpiration(document, path).getTime() <
+     now - CLOCK_SKEW_TOLERANCE_MS;
 
   const exp =
     document.issuerSigned.issuerAuth.decodedPayload.validityInfo.validUntil.getTime();
-  const isMDocExpired = checks.mdoc && exp < now;
+  const isMDocExpired = checks.mdoc && exp <
+   now - CLOCK_SKEW_TOLERANCE_MS;
 
   const isCertExpired =
     checks.cert &&
@@ -283,14 +286,14 @@ export function isCredentialSdJwtExpired(
   const isCredentialExpired =
     claimName !== undefined &&
     getCredentialSdJwtExpiration(parsed, claimName).getTime() <
-      now - EXPIRY_LEEWAY_MS;
+      now - CLOCK_SKEW_TOLERANCE_MS;
 
   const exp = parsed.jwt.payload?.exp;
   const isJwtExpired =
     checks.jwt &&
     exp !== undefined &&
     typeof exp === "number" &&
-    exp * 1000 < now - EXPIRY_LEEWAY_MS;
+    exp * 1000 < now - CLOCK_SKEW_TOLERANCE_MS;
 
   const jwt_trust_chain = zTrustChain.safeParse(parsed.jwt.header?.trust_chain);
   const isTrustChainExpired =

--- a/src/logic/federation-metadata.ts
+++ b/src/logic/federation-metadata.ts
@@ -10,6 +10,7 @@ import { Config, KeyPair, KeyPairJwk } from "@/types";
 import { signCallback, signJwtCallback } from "./jwt";
 import {
   buildJwksPath,
+  EXPIRY_LEEWAY_MS,
   loadJsonDumps,
   loadJwks,
   loadJwksWithX5C,
@@ -272,7 +273,9 @@ export const hasTrustChainExpired = (trust_chain: string[]) =>
     const decoded = decodeJwt(statement);
     const exp = decoded.payload.exp;
     return (
-      exp === undefined || typeof exp !== "number" || exp * 1000 <= Date.now()
+      exp === undefined ||
+      typeof exp !== "number" ||
+      exp * 1000 < Date.now() - EXPIRY_LEEWAY_MS
     );
   });
 

--- a/src/logic/federation-metadata.ts
+++ b/src/logic/federation-metadata.ts
@@ -10,10 +10,11 @@ import { Config, KeyPair, KeyPairJwk } from "@/types";
 import { signCallback, signJwtCallback } from "./jwt";
 import {
   buildJwksPath,
-  EXPIRY_LEEWAY_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   loadJsonDumps,
   loadJwks,
   loadJwksWithX5C,
+  VALIDITY_MS,
 } from "./utils";
 
 export interface CreateFederationMetadataOptions {
@@ -275,7 +276,7 @@ export const hasTrustChainExpired = (trust_chain: string[]) =>
     return (
       exp === undefined ||
       typeof exp !== "number" ||
-      exp * 1000 < Date.now() - EXPIRY_LEEWAY_MS
+      exp * 1000 < Date.now() - CLOCK_SKEW_TOLERANCE_MS
     );
   });
 
@@ -290,7 +291,7 @@ export async function getTrustMarks(
 
   const iat = Math.floor(Date.now() / 1000);
   const trustMarkPayload = {
-    exp: iat + 24 * 60 * 60 * 365,
+    exp: iat + (VALIDITY_MS / 1000),
     iat,
     iss: trust_anchor_base_url,
     logo_uri: "https://io.italia.it/assets/img/io-it-logo-blue.svg",

--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -8,3 +8,4 @@ export * from "./pem";
 export * from "./status-list";
 export * from "./utils";
 export * from "./vpToken";
+export * from "./wallet-provider";

--- a/src/logic/jwk.ts
+++ b/src/logic/jwk.ts
@@ -10,7 +10,8 @@ import { writeFileSync } from "node:fs";
 
 import { KeyPair, KeyPairJwk } from "@/types";
 
-import { buildCertPath, loadCertificate } from "./utils";
+import { loadCertificate } from "./pem";
+import { buildCertPath } from "./utils";
 
 /**
  * Generates a new cryptographic key pair (ECDSA with P-256 curve) and saves it to a file.

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -1,11 +1,18 @@
 import * as x509 from "@peculiar/x509";
-import { mkdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
-import { KeyPair } from "@/types";
+import { CertificateExpiredError } from "@/errors";
+import { Config, KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
-import { EXPIRY_LEEWAY_MS } from "./utils";
+import { ensureDir, EXPIRY_LEEWAY_MS } from "./utils";
 
 /**
  * Creates a self-signed X.509 certificate and saves it to a file in PEM format.
@@ -141,6 +148,135 @@ export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
   return certificate.notAfter.getTime() < Date.now() - EXPIRY_LEEWAY_MS;
+}
+
+/**
+ * Loads a certificate from a file, or creates and saves it if it doesn't exist.
+ *
+ * @param certPath The directory path where the certificate is stored.
+ * @param filename The name of the certificate file.
+ * @param keyPair The key pair to use if creating a new certificate.
+ * @param subject The subject name to use if creating a new certificate.
+ * @returns A promise that resolves to the certificate in PEM format.
+ */
+export async function loadCertificate(
+  certPath: string,
+  filename: string,
+  keyPair: KeyPair,
+  subject: string,
+): Promise<string> {
+  const dirCreated = ensureDir(certPath);
+
+  if (!dirCreated) {
+    try {
+      const certPem = readFileSync(`${certPath}/${filename}`, "utf-8");
+      const certDerBase64 = certPem
+        .replace("-----BEGIN CERTIFICATE-----", "")
+        .replace("-----END CERTIFICATE-----", "")
+        .replace(/\s+/g, "")
+        .trim();
+
+      if (hasX509CertificateExpired(certDerBase64))
+        throw new CertificateExpiredError(
+          "Certificate has expired and has to be regenerated",
+        );
+
+      return certDerBase64;
+    } catch {
+      /* fall through to generate */
+    }
+  }
+
+  return await createAndSaveCertificate(
+    `${certPath}/${filename}`,
+    keyPair,
+    subject,
+  );
+}
+
+/**
+ * Loads an existing cert/key pair from `dir` if one is present, otherwise
+ * creates a new one via {@link createAndSaveCertificateWithKey}.
+ *
+ * File discovery: looks for `${baseName}.cert.pem` and `${baseName}.key.pem` in `dir`.
+ * Falls through to creation if the directory is absent, those files are missing,
+ * or either file cannot be read.
+ *
+ * @param dir Directory to search or write files into.
+ * @param baseName Base filename (without extension) for the cert and key files.
+ * @param subject The subject / CN — used only when creation is needed.
+ * @param extraExtensions Additional X.509 extensions — used only when creation is needed.
+ * @returns The cert PEM, key PEM, and absolute paths of the cert and key files.
+ */
+export async function loadOrCreateCertificateWithKey(
+  dir: string,
+  baseName: string,
+  subject: string,
+  extraExtensions: x509.Extension[] = [],
+): Promise<{
+  certPath: string;
+  certPem: string;
+  keyPath: string;
+  keyPem: string;
+}> {
+  const dirCreated = ensureDir(dir);
+
+  if (!dirCreated) {
+    const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
+    const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
+    if (existsSync(certPath) && existsSync(keyPath)) {
+      try {
+        const certPem = readFileSync(certPath, "utf-8");
+        const keyPem = readFileSync(keyPath, "utf-8");
+        //TODO: Await WLEO-885 to replace with proper expiration check method
+        const cert = new x509.X509Certificate(certPem);
+        if (hasX509CertificateExpired(cert)) {
+          rmSync(certPath);
+          rmSync(keyPath);
+          //We throw an error to explicitly mark the fact that the flow is stopped,
+          //falling through here makes the code far less understandable.
+          throw new CertificateExpiredError("Stored certificate has expired");
+        } else {
+          return { certPath, certPem, keyPath, keyPem };
+        }
+      } catch {
+        /* fall through to generate */
+      }
+    }
+  }
+
+  return createAndSaveCertificateWithKey(
+    dir,
+    baseName,
+    subject,
+    extraExtensions,
+  );
+}
+
+/**
+ * Loads (or lazily generates and caches on disk) an X.509 certificate for the
+ * wallet provider key pair, suitable for use in
+ * WalletAttestationOptionsV1_3.signer.x5c.
+ *
+ * Follows the same lazy-cache pattern as loadCertificate /
+ * loadTAJwksWithSelfSignedX5c.
+ *
+ * @param wallet - The wallet configuration section from Config
+ * @param providerKeyPair - The provider key pair loaded from backup_storage_path
+ * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
+ */
+export async function loadWalletProviderCertificate(
+  wallet: Config["wallet"],
+  providerKeyPair: KeyPair,
+): Promise<[string, ...string[]]> {
+  const providerDomain = new URL(wallet.wallet_provider_base_url).hostname;
+  const cert = await loadCertificate(
+    wallet.backup_storage_path,
+    "wallet_provider_cert",
+    providerKeyPair,
+    `CN=${providerDomain}`,
+  );
+  return [cert];
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
+import { EXPIRY_LEEWAY_MS } from "./utils";
 
 /**
  * Creates a self-signed X.509 certificate and saves it to a file in PEM format.
@@ -113,7 +114,8 @@ export async function createCertificate(
   const keys = { privateKey, publicKey };
 
   // Create self-signed cert (X.509)
-  const now = new Date();
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore.getTime() + 1000 * 60 * 60 * 24 * 365);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
     extensions: [
       new x509.BasicConstraintsExtension(false, undefined, true),
@@ -127,7 +129,8 @@ export async function createCertificate(
     ],
     keys,
     name: subject,
-    notBefore: now,
+    notAfter,
+    notBefore,
     signingAlgorithm,
   });
 
@@ -137,7 +140,7 @@ export async function createCertificate(
 export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
-  return certificate.notAfter.getTime() < Date.now();
+  return certificate.notAfter.getTime() < Date.now() - EXPIRY_LEEWAY_MS;
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -9,6 +9,7 @@ import {
 import path from "node:path";
 
 import { CertificateExpiredError } from "@/errors";
+import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { Config, KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
@@ -269,7 +270,7 @@ export async function loadWalletProviderCertificate(
   wallet: Config["wallet"],
   providerKeyPair: KeyPair,
 ): Promise<[string, ...string[]]> {
-  const providerDomain = new URL(wallet.wallet_provider_base_url).hostname;
+  const providerDomain = LOCAL_WP_HOST;
   const cert = await loadCertificate(
     wallet.backup_storage_path,
     "wallet_provider_cert",

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -9,11 +9,10 @@ import {
 import path from "node:path";
 
 import { CertificateExpiredError } from "@/errors";
-import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { Config, KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
-import { ensureDir, EXPIRY_LEEWAY_MS } from "./utils";
+import { ensureDir, CLOCK_SKEW_TOLERANCE_MS, VALIDITY_MS } from "./utils";
 
 /**
  * Creates a self-signed X.509 certificate and saves it to a file in PEM format.
@@ -123,7 +122,7 @@ export async function createCertificate(
 
   // Create self-signed cert (X.509)
   const notBefore = new Date();
-  const notAfter = new Date(notBefore.getTime() + 1000 * 60 * 60 * 24 * 365);
+  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
     extensions: [
       new x509.BasicConstraintsExtension(false, undefined, true),
@@ -148,7 +147,7 @@ export async function createCertificate(
 export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
-  return certificate.notAfter.getTime() < Date.now() - EXPIRY_LEEWAY_MS;
+  return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
 }
 
 /**
@@ -158,7 +157,9 @@ export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
  * @param filename The name of the certificate file.
  * @param keyPair The key pair to use if creating a new certificate.
  * @param subject The subject name to use if creating a new certificate.
- * @returns A promise that resolves to the certificate in PEM format.
+ * @returns A promise that resolves to the base64-DER encoded certificate
+ *          (DER-encoded X.509, base64-encoded, no PEM headers) — suitable
+ *          for use in an x5c header array per RFC 7517 §4.7.
  */
 export async function loadCertificate(
   certPath: string,
@@ -252,32 +253,6 @@ export async function loadOrCreateCertificateWithKey(
     subject,
     extraExtensions,
   );
-}
-
-/**
- * Loads (or lazily generates and caches on disk) an X.509 certificate for the
- * wallet provider key pair, suitable for use in
- * WalletAttestationOptionsV1_3.signer.x5c.
- *
- * Follows the same lazy-cache pattern as loadCertificate /
- * loadTAJwksWithSelfSignedX5c.
- *
- * @param wallet - The wallet configuration section from Config
- * @param providerKeyPair - The provider key pair loaded from backup_storage_path
- * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
- */
-export async function loadWalletProviderCertificate(
-  wallet: Config["wallet"],
-  providerKeyPair: KeyPair,
-): Promise<[string, ...string[]]> {
-  const providerDomain = LOCAL_WP_HOST;
-  const cert = await loadCertificate(
-    wallet.backup_storage_path,
-    "wallet_provider_cert",
-    providerKeyPair,
-    `CN=${providerDomain}`,
-  );
-  return [cert];
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -227,22 +227,15 @@ export async function loadOrCreateCertificateWithKey(
     const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
     const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
     if (existsSync(certPath) && existsSync(keyPath)) {
-      try {
-        const certPem = readFileSync(certPath, "utf-8");
-        const keyPem = readFileSync(keyPath, "utf-8");
-        //TODO: Await WLEO-885 to replace with proper expiration check method
-        const cert = new x509.X509Certificate(certPem);
-        if (hasX509CertificateExpired(cert)) {
-          rmSync(certPath);
-          rmSync(keyPath);
-          //We throw an error to explicitly mark the fact that the flow is stopped,
-          //falling through here makes the code far less understandable.
-          throw new CertificateExpiredError("Stored certificate has expired");
-        } else {
-          return { certPath, certPem, keyPath, keyPem };
-        }
-      } catch {
-        /* fall through to generate */
+      const certPem = readFileSync(certPath, "utf-8");
+      const keyPem = readFileSync(keyPath, "utf-8");
+
+      const cert = new x509.X509Certificate(certPem);
+      if (hasX509CertificateExpired(cert)) {
+        rmSync(certPath);
+        rmSync(keyPath);
+      } else {
+        return { certPath, certPem, keyPath, keyPem };
       }
     }
   }

--- a/src/logic/status-list.ts
+++ b/src/logic/status-list.ts
@@ -7,7 +7,8 @@ import {
 import { StatusListTokenCreationError } from "@/errors";
 
 import { signJwtCallback } from "./jwt";
-import { hasObjectProperties, loadCertificate, loadJwks } from "./utils";
+import { loadCertificate } from "./pem";
+import { hasObjectProperties, loadJwks } from "./utils";
 
 export interface CreateStatusListTokenOptions {
   certFilename: string;

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -5,31 +5,17 @@ import {
   Fetch,
   ItWalletSpecsVersion,
 } from "@pagopa/io-wallet-utils";
-import * as x509 from "@peculiar/x509";
 import { BinaryLike, createHash, randomBytes } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "path";
 
-import { CertificateExpiredError, MissingFieldError } from "@/errors";
 import { LOCAL_CI_HOST } from "@/servers/ci-server";
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
+import { MissingFieldError } from "@/errors";
 import { Config, FetchWithRetriesResponse, KeyPair } from "@/types";
 
-import {
-  createAndSaveCertificate,
-  createAndSaveCertificateWithKey,
-  createAndSaveKeys,
-  createAndSaveKeysWithX5C,
-  hasX509CertificateExpired,
-  verifyJwt,
-} from ".";
+import { createAndSaveKeys, createAndSaveKeysWithX5C, verifyJwt } from ".";
 
 export const EXPIRY_LEEWAY_MS = 3e4;
 
@@ -224,50 +210,6 @@ export function ensureDir(dirPath: string): boolean {
       `unable to find or create necessary directory ${dirPath}: ${(e as Error).message}`,
     );
   }
-}
-
-/**
- * Loads a certificate from a file, or creates and saves it if it doesn't exist.
- *
- * @param certPath The directory path where the certificate is stored.
- * @param filename The name of the certificate file.
- * @param keyPair The key pair to use if creating a new certificate.
- * @param subject The subject name to use if creating a new certificate.
- * @returns A promise that resolves to the certificate in PEM format.
- */
-export async function loadCertificate(
-  certPath: string,
-  filename: string,
-  keyPair: KeyPair,
-  subject: string,
-): Promise<string> {
-  const dirCreated = ensureDir(certPath);
-
-  if (!dirCreated) {
-    try {
-      const certPem = readFileSync(`${certPath}/${filename}`, "utf-8");
-      const certDerBase64 = certPem
-        .replace("-----BEGIN CERTIFICATE-----", "")
-        .replace("-----END CERTIFICATE-----", "")
-        .replace(/\s+/g, "")
-        .trim();
-
-      if (hasX509CertificateExpired(certDerBase64))
-        throw new CertificateExpiredError(
-          "Certificate has expired and has to be regenerated",
-        );
-
-      return certDerBase64;
-    } catch {
-      /* fall through to generate */
-    }
-  }
-
-  return await createAndSaveCertificate(
-    `${certPath}/${filename}`,
-    keyPair,
-    subject,
-  );
 }
 
 /**

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -23,7 +23,8 @@ import {
   verifyJwt,
 } from ".";
 
-export const EXPIRY_LEEWAY_MS = 3e4;
+export const CLOCK_SKEW_TOLERANCE_MS = 30_000;
+export const VALIDITY_MS = 1000 * 60 * 60 * 24 * 365;
 
 // Re-export config loading functions
 export {

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -5,17 +5,23 @@ import {
   Fetch,
   ItWalletSpecsVersion,
 } from "@pagopa/io-wallet-utils";
+import * as x509 from "@peculiar/x509";
 import { BinaryLike, createHash, randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "path";
 
+import { MissingFieldError } from "@/errors";
 import { LOCAL_CI_HOST } from "@/servers/ci-server";
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
-import { MissingFieldError } from "@/errors";
 import { Config, FetchWithRetriesResponse, KeyPair } from "@/types";
 
-import { createAndSaveKeys, createAndSaveKeysWithX5C, verifyJwt } from ".";
+import {
+  createAndSaveKeys,
+  createAndSaveKeysWithX5C,
+  loadOrCreateCertificateWithKey,
+  verifyJwt,
+} from ".";
 
 export const EXPIRY_LEEWAY_MS = 3e4;
 
@@ -269,65 +275,6 @@ export async function loadJwksWithX5C(
 }
 
 /**
- * Loads an existing cert/key pair from `dir` if one is present, otherwise
- * creates a new one via {@link createAndSaveCertificateWithKey}.
- *
- * File discovery: looks for `${baseName}.cert.pem` and `${baseName}.key.pem` in `dir`.
- * Falls through to creation if the directory is absent, those files are missing,
- * or either file cannot be read.
- *
- * @param dir Directory to search or write files into.
- * @param baseName Base filename (without extension) for the cert and key files.
- * @param subject The subject / CN — used only when creation is needed.
- * @param extraExtensions Additional X.509 extensions — used only when creation is needed.
- * @returns The cert PEM, key PEM, and absolute paths of the cert and key files.
- */
-export async function loadOrCreateCertificateWithKey(
-  dir: string,
-  baseName: string,
-  subject: string,
-  extraExtensions: x509.Extension[] = [],
-): Promise<{
-  certPath: string;
-  certPem: string;
-  keyPath: string;
-  keyPem: string;
-}> {
-  const dirCreated = ensureDir(dir);
-
-  if (!dirCreated) {
-    const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
-    const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
-    if (existsSync(certPath) && existsSync(keyPath)) {
-      try {
-        const certPem = readFileSync(certPath, "utf-8");
-        const keyPem = readFileSync(keyPath, "utf-8");
-        //TODO: Await WLEO-885 to replace with proper expiration check method
-        const cert = new x509.X509Certificate(certPem);
-        if (hasX509CertificateExpired(cert)) {
-          rmSync(certPath);
-          rmSync(keyPath);
-          //We throw an error to explicitly mark the fact that the flow is stopped,
-          //falling through here makes the code far less understandable.
-          throw new CertificateExpiredError("Stored certificate has expired");
-        } else {
-          return { certPath, certPem, keyPath, keyPem };
-        }
-      } catch {
-        /* fall through to generate */
-      }
-    }
-  }
-
-  return createAndSaveCertificateWithKey(
-    dir,
-    baseName,
-    subject,
-    extraExtensions,
-  );
-}
-
-/**
  *  Loads an existing server certificate/key pair from the specified config, or creates a new one if not found or expired.
  * @param config The application configuration containing paths and parameters for certificate management.
  * @returns A promise that resolves to the loaded or generated server certificate and key.
@@ -357,32 +304,6 @@ export const loadOrCreateServerCertificate = async (
     ]);
   return { certPath, certPem, keyPath, keyPem };
 };
-
-/**
- * Loads (or lazily generates and caches on disk) an X.509 certificate for the
- * wallet provider key pair, suitable for use in
- * WalletAttestationOptionsV1_3.signer.x5c.
- *
- * Follows the same lazy-cache pattern as loadCertificate /
- * loadTAJwksWithSelfSignedX5c.
- *
- * @param wallet - The wallet configuration section from Config
- * @param providerKeyPair - The provider key pair loaded from backup_storage_path
- * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
- */
-export async function loadWalletProviderCertificate(
-  wallet: Config["wallet"],
-  providerKeyPair: KeyPair,
-): Promise<[string, ...string[]]> {
-  const providerDomain = LOCAL_WP_HOST;
-  const cert = await loadCertificate(
-    wallet.backup_storage_path,
-    "wallet_provider_cert",
-    providerKeyPair,
-    `CN=${providerDomain}`,
-  );
-  return [cert];
-}
 
 /**
  * Saves a credential to disk.

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -31,6 +31,8 @@ import {
   verifyJwt,
 } from ".";
 
+export const EXPIRY_LEEWAY_MS = 3e4;
+
 // Re-export config loading functions
 export {
   type CliOptions,

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,0 +1,30 @@
+import { LOCAL_WP_HOST } from "@/servers/wp-server";
+import { loadCertificate } from "./pem";
+import { Config, KeyPair } from "@/types";
+
+
+/**
+ * Loads (or lazily generates and caches on disk) an X.509 certificate for the
+ * wallet provider key pair, suitable for use in
+ * WalletAttestationOptionsV1_3.signer.x5c.
+ *
+ * Follows the same lazy-cache pattern as loadCertificate /
+ * loadTAJwksWithSelfSignedX5c.
+ *
+ * @param wallet - The wallet configuration section from Config
+ * @param providerKeyPair - The provider key pair loaded from backup_storage_path
+ * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
+ */
+export async function loadWalletProviderCertificate(
+  wallet: Config["wallet"],
+  providerKeyPair: KeyPair,
+): Promise<[string, ...string[]]> {
+  const providerDomain = LOCAL_WP_HOST;
+  const cert = await loadCertificate(
+    wallet.backup_storage_path,
+    "wallet_provider_cert",
+    providerKeyPair,
+    `CN=${providerDomain}`,
+  );
+  return [cert];
+}

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -29,6 +29,7 @@ import {
   createKeys,
   createLogger,
   createVpTokenMdoc,
+  EXPIRY_LEEWAY_MS,
   loadCertificate,
   loadConfig,
   loadJsonDumps,
@@ -171,7 +172,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(expiration) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(expiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialSdJwtExpired(pid.parsed, "expiry_date", {
               jwt: false,
@@ -201,7 +204,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the jwt expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((jwtExpiration + 1) * 1000);
+          vi.setSystemTime((jwtExpiration + EXPIRY_LEEWAY_MS + 1) * 1000);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: true,
@@ -245,7 +248,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the trust_chain expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((trustChainMinExp + 1) * 1000);
+          vi.setSystemTime((trustChainMinExp + EXPIRY_LEEWAY_MS + 1) * 1000);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: false,
@@ -284,7 +287,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the x5c certificate expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(x5cMinExp) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(x5cMinExp) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: false,
@@ -335,7 +340,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(expiration) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(expiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialMdocExpired(
               mDL.parsed,
@@ -366,7 +373,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the mdoc expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(mDocExpiration) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(mDocExpiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
               cert: false,
@@ -393,7 +402,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the certificate expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(certExpiration) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(certExpiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
               cert: true,
@@ -433,7 +444,9 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the trust chain certificate expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((dateToSeconds(trustChainMinExp) + 1) * 1000);
+          vi.setSystemTime(
+            (dateToSeconds(trustChainMinExp) + EXPIRY_LEEWAY_MS + 1) * 1000,
+          );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
               cert: false,

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -173,7 +173,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(expiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(expiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialSdJwtExpired(pid.parsed, "expiry_date", {
@@ -204,7 +204,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the jwt expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((jwtExpiration + EXPIRY_LEEWAY_MS + 1) * 1000);
+          vi.setSystemTime((jwtExpiration + 1) * 1000 + EXPIRY_LEEWAY_MS);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: true,
@@ -248,7 +248,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the trust_chain expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((trustChainMinExp + EXPIRY_LEEWAY_MS + 1) * 1000);
+          vi.setSystemTime((trustChainMinExp + 1) * 1000 + EXPIRY_LEEWAY_MS);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: false,
@@ -288,7 +288,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the x5c certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(x5cMinExp) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(x5cMinExp) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
@@ -341,7 +341,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(expiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(expiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialMdocExpired(
@@ -374,7 +374,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the mdoc expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(mDocExpiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(mDocExpiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
@@ -403,7 +403,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(certExpiration) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(certExpiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
@@ -445,7 +445,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the trust chain certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(trustChainMinExp) + EXPIRY_LEEWAY_MS + 1) * 1000,
+            (dateToSeconds(trustChainMinExp) + 1) * 1000 + EXPIRY_LEEWAY_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -29,7 +29,7 @@ import {
   createKeys,
   createLogger,
   createVpTokenMdoc,
-  EXPIRY_LEEWAY_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   loadCertificate,
   loadConfig,
   loadJsonDumps,
@@ -173,7 +173,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(expiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(expiration) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialSdJwtExpired(pid.parsed, "expiry_date", {
@@ -204,7 +204,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the jwt expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((jwtExpiration + 1) * 1000 + EXPIRY_LEEWAY_MS);
+          vi.setSystemTime((jwtExpiration + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: true,
@@ -248,7 +248,7 @@ describe("Load Mocked Credentials", async () => {
         });
         it("should return true because it's not past the trust_chain expiration", async () => {
           // Set system time to a second after expiration
-          vi.setSystemTime((trustChainMinExp + 1) * 1000 + EXPIRY_LEEWAY_MS);
+          vi.setSystemTime((trustChainMinExp + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS);
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
               jwt: false,
@@ -288,7 +288,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the x5c certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(x5cMinExp) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(x5cMinExp) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialSdJwtExpired(pid.parsed, undefined, {
@@ -341,7 +341,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the expiration date claim", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(expiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(expiration) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialMdocExpired(
@@ -374,7 +374,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the mdoc expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(mDocExpiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(mDocExpiration) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
@@ -403,7 +403,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(certExpiration) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(certExpiration) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {
@@ -445,7 +445,7 @@ describe("Load Mocked Credentials", async () => {
         it("should return true because it's not past the trust chain certificate expiration", async () => {
           // Set system time to a second after expiration
           vi.setSystemTime(
-            (dateToSeconds(trustChainMinExp) + 1) * 1000 + EXPIRY_LEEWAY_MS,
+            (dateToSeconds(trustChainMinExp) + 1) * 1000 + CLOCK_SKEW_TOLERANCE_MS,
           );
           expect(
             isCredentialMdocExpired(mDL.parsed, undefined, {

--- a/tests/unit/status-list.unit.spec.ts
+++ b/tests/unit/status-list.unit.spec.ts
@@ -3,6 +3,7 @@ import { decodeJwt, decodeProtectedHeader, importX509, jwtVerify } from "jose";
 import { describe, expect, it, vi } from "vitest";
 
 import { loadConfigWithHierarchy } from "@/logic";
+import * as pem from "@/logic/pem";
 import { createStatusListToken } from "@/logic/status-list";
 import * as utils from "@/logic/utils";
 import { getLocalCiBaseUrl } from "@/servers/ci-server";
@@ -151,7 +152,7 @@ describe("createStatusListToken", () => {
       privateKey: { alg: "ES256", kty: "EC" } as never,
       publicKey: { kty: "EC" } as never, // no alg
     });
-    vi.spyOn(utils, "loadCertificate").mockResolvedValueOnce("dummycert");
+    vi.spyOn(pem, "loadCertificate").mockResolvedValueOnce("dummycert");
 
     await expect(createStatusListToken(walletOptions)).rejects.toThrow(
       /Error, the following keys are missing from object: alg/,


### PR DESCRIPTION
#### Motivation and Context

This change improves the robustness and reliability of the conformance tests by addressing two key issues in certificate and token validation:

   1. Mock Certificate Expiration: Previously, mock certificates created via `createCertificate` lacked an explicit `notAfter` date. They now include a standard one-year validity period from the time of creation, ensuring they are properly bounded and compliant with X.509
      expectations.
   2. Clock-Skew Handling: Strict expiration checks for Wallet Instance Attestations (WIA), SD-JWTs, and X.509 trust chains could lead to intermittent failures in environments with minor time synchronization offsets. By introducing a 30-second leeway
      (`EXPIRY_LEEWAY_MS`), the system now gracefully accounts for clock-skew during validation.

  These updates ensure that "just-expired" errors are minimized and that the mock data used throughout the test suite more accurately reflects production-grade security artifacts. All related unit tests have been updated to respect this new leeway when mocking system
  time.

JIRA Ticket: WLEO-1035