### PR TITLE
Update hostnames to use example domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ The tool spins up several **local HTTPS servers** that provide OpenID Federation
 
 | Server | Hostname | Default Port | Purpose |
 |---|---|---|---|
-| **Trust Anchor** | `trust-anchor.wct.it` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
-| **Wallet Provider** | `wallet-provider.wct.it` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
-| **Credential Issuer** | `credential-issuer.wct.it` | `3003` | Exposes the mock PID issuer entity configuration |
+| **Trust Anchor** | `trust-anchor.wct.example.it` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
+| **Wallet Provider** | `wallet-provider.wct.example.it` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
+| **Credential Issuer** | `credential-issuer.wct.example.it` | `3003` | Exposes the mock PID issuer entity configuration |
 
 ### DNS Resolution Requirement
 
@@ -356,7 +356,7 @@ Because these servers listen on HTTPS (port 443 implied by the canonical URLs), 
 Add the following line to `/etc/hosts` (requires `sudo`):
 
 ```bash
-sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.it wallet-provider.wct.it credential-issuer.wct.it" >> /etc/hosts'
+sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it" >> /etc/hosts'
 ```
 
 Or open the file manually:
@@ -368,7 +368,7 @@ sudo nano /etc/hosts
 And append:
 
 ```
-127.0.0.1  trust-anchor.wct.it wallet-provider.wct.it credential-issuer.wct.it
+127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it
 ```
 
 #### Windows
@@ -382,13 +382,13 @@ C:\Windows\System32\drivers\etc\hosts
 Append the following line and save:
 
 ```
-127.0.0.1  trust-anchor.wct.it wallet-provider.wct.it credential-issuer.wct.it
+127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it
 ```
 
 > **Tip:** You can also run the following command in an **Administrator PowerShell** prompt:
 >
 > ```powershell
-> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.it wallet-provider.wct.it credential-issuer.wct.it"
+> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it"
 > ```
 
 ### Automatic Startup

--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ The tool spins up several **local HTTPS servers** that provide OpenID Federation
 
 | Server | Hostname | Default Port | Purpose |
 |---|---|---|---|
-| **Trust Anchor** | `trust-anchor.wct.example.it` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
-| **Wallet Provider** | `wallet-provider.wct.example.it` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
-| **Credential Issuer** | `credential-issuer.wct.example.it` | `3003` | Exposes the mock PID issuer entity configuration |
+| **Trust Anchor** | `trust-anchor.wct.example` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
+| **Wallet Provider** | `wallet-provider.wct.example` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
+| **Credential Issuer** | `credential-issuer.wct.example` | `3003` | Exposes the mock PID issuer entity configuration |
 
 ### DNS Resolution Requirement
 
@@ -356,7 +356,7 @@ Because these servers listen on HTTPS (port 443 implied by the canonical URLs), 
 Add the following line to `/etc/hosts` (requires `sudo`):
 
 ```bash
-sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it" >> /etc/hosts'
+sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example" >> /etc/hosts'
 ```
 
 Or open the file manually:
@@ -368,7 +368,7 @@ sudo nano /etc/hosts
 And append:
 
 ```
-127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it
+127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example
 ```
 
 #### Windows
@@ -382,13 +382,13 @@ C:\Windows\System32\drivers\etc\hosts
 Append the following line and save:
 
 ```
-127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it
+127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example
 ```
 
 > **Tip:** You can also run the following command in an **Administrator PowerShell** prompt:
 >
 > ```powershell
-> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.example.it wallet-provider.wct.example.it credential-issuer.wct.example.it"
+> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example"
 > ```
 
 ### Automatic Startup

--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ The tool spins up several **local HTTPS servers** that provide OpenID Federation
 
 | Server | Hostname | Default Port | Purpose |
 |---|---|---|---|
-| **Trust Anchor** | `trust-anchor.wct.example` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
-| **Wallet Provider** | `wallet-provider.wct.example` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
-| **Credential Issuer** | `credential-issuer.wct.example` | `3003` | Exposes the mock PID issuer entity configuration |
+| **Trust Anchor** | `trust-anchor.wct.example.org` | `3001` | Root of trust — serves `openid-federation` and `/fetch` endpoints |
+| **Wallet Provider** | `wallet-provider.wct.example.org` | `3002` | Exposes the Wallet Provider entity configuration and JWKS |
+| **Credential Issuer** | `credential-issuer.wct.example.org` | `3003` | Exposes the mock PID issuer entity configuration |
 
 ### DNS Resolution Requirement
 
@@ -356,7 +356,7 @@ Because these servers listen on HTTPS (port 443 implied by the canonical URLs), 
 Add the following line to `/etc/hosts` (requires `sudo`):
 
 ```bash
-sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example" >> /etc/hosts'
+sudo sh -c 'echo "127.0.0.1  trust-anchor.wct.example.org wallet-provider.wct.example.org credential-issuer.wct.example.org" >> /etc/hosts'
 ```
 
 Or open the file manually:
@@ -368,7 +368,7 @@ sudo nano /etc/hosts
 And append:
 
 ```
-127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example
+127.0.0.1  trust-anchor.wct.example.org wallet-provider.wct.example.org credential-issuer.wct.example.org
 ```
 
 #### Windows
@@ -382,13 +382,13 @@ C:\Windows\System32\drivers\etc\hosts
 Append the following line and save:
 
 ```
-127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example
+127.0.0.1  trust-anchor.wct.example.org wallet-provider.wct.example.org credential-issuer.wct.example.org
 ```
 
 > **Tip:** You can also run the following command in an **Administrator PowerShell** prompt:
 >
 > ```powershell
-> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.example wallet-provider.wct.example credential-issuer.wct.example"
+> Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value "127.0.0.1  trust-anchor.wct.example.org wallet-provider.wct.example.org credential-issuer.wct.example.org"
 > ```
 
 ### Automatic Startup

--- a/config.example.ini
+++ b/config.example.ini
@@ -31,7 +31,7 @@ federation_trust_anchors[] = [array of urls]
 federation_trust_anchors_jwks_path = ./data/federation_trust_anchors/localhost # each named with the related TA name
 
 [issuance]
-url = https://issuer.example.it
+url = https://issuer.example
 
 # Optional: override the directory where issuance test specs are discovered
 # tests_dir = ./tests/conformance/issuance
@@ -46,17 +46,17 @@ credential_types[] = dc_sd_jwt_EuropeanDisabilityCard
 
 # Optional: enable credential offer resolution if present
 # The credential_issuer field in the response will override the issuance url. 
-# credential_offer_uri=https://offer.example.it
+# credential_offer_uri=https://offer.example
 
 [presentation]
 # Optional: override the directory where presentation test specs are discovered
 # tests_dir = ./tests/conformance/presentation
 
 # Optional: RP Verifier URL in case endpoint metadata is different from the authorize_request_url domain
-# verifier = https://rp-example.example.it
+# verifier = https://rp-example.example
 
 # URL to initiate the presentation request, metadata will be fetched from client_id domain if [verifier] is not set
-authorize_request_url = https://rp-example.example.it/auth?client_id=https://rp-example.example.it&request_uri=https://rp-example.example.it/auth/request/2f4c8d91-7b35-4e2a-9c1d-5a6f8b3e2d10&state=2f4c8d91-7b35-4e2a-9c1d-5a6f8b3e2d10
+authorize_request_url = https://rp-example.example/auth?client_id=https://rp-example.example&request_uri=https://rp-example.example/auth/request/2f4c8d91-7b35-4e2a-9c1d-5a6f8b3e2d10&state=2f4c8d91-7b35-4e2a-9c1d-5a6f8b3e2d10
 
 
 [network]
@@ -86,8 +86,8 @@ tls_cert_dir = ./data/backup
 # and fetches the Wallet Provider Subordinate Statement from it.
 # The local TA always starts regardless (needed for the mock PID issuer).
 #
-# external_ta_url            = https://trust-anchor.example.it
-# external_ta_onboarding_url = https://trust-anchor.example.it/onboarding
+# external_ta_url            = https://trust-anchor.example
+# external_ta_onboarding_url = https://trust-anchor.example/onboarding
 
 [logging]
 # Logging Configuration

--- a/src/servers/ci-server.ts
+++ b/src/servers/ci-server.ts
@@ -13,7 +13,7 @@ import {
 } from "@/logic";
 import { Config } from "@/types";
 
-export const LOCAL_CI_HOST = "credential-issuer.wct.example";
+export const LOCAL_CI_HOST = "credential-issuer.wct.example.org";
 export const getLocalCiBaseUrl = (port: number): string =>
   `https://${LOCAL_CI_HOST}:${port}`;
 

--- a/src/servers/ci-server.ts
+++ b/src/servers/ci-server.ts
@@ -13,7 +13,7 @@ import {
 } from "@/logic";
 import { Config } from "@/types";
 
-export const LOCAL_CI_HOST = "credential-issuer.wct.example.it";
+export const LOCAL_CI_HOST = "credential-issuer.wct.example";
 export const getLocalCiBaseUrl = (port: number): string =>
   `https://${LOCAL_CI_HOST}:${port}`;
 

--- a/src/servers/ci-server.ts
+++ b/src/servers/ci-server.ts
@@ -13,7 +13,7 @@ import {
 } from "@/logic";
 import { Config } from "@/types";
 
-export const LOCAL_CI_HOST = "credential-issuer.wct.it";
+export const LOCAL_CI_HOST = "credential-issuer.wct.example.it";
 export const getLocalCiBaseUrl = (port: number): string =>
   `https://${LOCAL_CI_HOST}:${port}`;
 

--- a/src/servers/wp-server.ts
+++ b/src/servers/wp-server.ts
@@ -12,7 +12,7 @@ import { createStatusListToken } from "@/logic/status-list";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config } from "@/types";
 
-export const LOCAL_WP_HOST = "wallet-provider.wct.example";
+export const LOCAL_WP_HOST = "wallet-provider.wct.example.org";
 export const getLocalWpBaseUrl = (port: number): string =>
   `https://${LOCAL_WP_HOST}:${port}`;
 

--- a/src/servers/wp-server.ts
+++ b/src/servers/wp-server.ts
@@ -12,7 +12,7 @@ import { createStatusListToken } from "@/logic/status-list";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config } from "@/types";
 
-export const LOCAL_WP_HOST = "wallet-provider.wct.example.it";
+export const LOCAL_WP_HOST = "wallet-provider.wct.example";
 export const getLocalWpBaseUrl = (port: number): string =>
   `https://${LOCAL_WP_HOST}:${port}`;
 

--- a/src/servers/wp-server.ts
+++ b/src/servers/wp-server.ts
@@ -12,7 +12,7 @@ import { createStatusListToken } from "@/logic/status-list";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config } from "@/types";
 
-export const LOCAL_WP_HOST = "wallet-provider.wct.it";
+export const LOCAL_WP_HOST = "wallet-provider.wct.example.it";
 export const getLocalWpBaseUrl = (port: number): string =>
   `https://${LOCAL_WP_HOST}:${port}`;
 

--- a/src/trust-anchor/trust-anchor-resolver.ts
+++ b/src/trust-anchor/trust-anchor-resolver.ts
@@ -1,6 +1,6 @@
 import { Config } from "@/types";
 
-export const LOCAL_TA_HOST = "trust-anchor.wct.it";
+export const LOCAL_TA_HOST = "trust-anchor.wct.example.it";
 export const LOCAL_TA_BASE_URL = `https://${LOCAL_TA_HOST}`;
 
 /**

--- a/src/trust-anchor/trust-anchor-resolver.ts
+++ b/src/trust-anchor/trust-anchor-resolver.ts
@@ -1,6 +1,6 @@
 import { Config } from "@/types";
 
-export const LOCAL_TA_HOST = "trust-anchor.wct.example";
+export const LOCAL_TA_HOST = "trust-anchor.wct.example.org";
 export const LOCAL_TA_BASE_URL = `https://${LOCAL_TA_HOST}`;
 
 /**

--- a/src/trust-anchor/trust-anchor-resolver.ts
+++ b/src/trust-anchor/trust-anchor-resolver.ts
@@ -1,6 +1,6 @@
 import { Config } from "@/types";
 
-export const LOCAL_TA_HOST = "trust-anchor.wct.example.it";
+export const LOCAL_TA_HOST = "trust-anchor.wct.example";
 export const LOCAL_TA_BASE_URL = `https://${LOCAL_TA_HOST}`;
 
 /**

--- a/tests/unit/status-list.unit.spec.ts
+++ b/tests/unit/status-list.unit.spec.ts
@@ -70,7 +70,7 @@ describe("createStatusListToken", () => {
 
   const walletOptions = {
     certFilename: "wallet_provider_cert",
-    certSubject: `CN=wallet-provider.wct.example.it`,
+    certSubject: `CN=wallet-provider.wct.example`,
     iss: getLocalWpBaseUrl(config.wallet.port),
     jwksFilename: "wallet_provider_jwks",
     jwksPath: config.wallet.backup_storage_path,

--- a/tests/unit/status-list.unit.spec.ts
+++ b/tests/unit/status-list.unit.spec.ts
@@ -70,7 +70,7 @@ describe("createStatusListToken", () => {
 
   const walletOptions = {
     certFilename: "wallet_provider_cert",
-    certSubject: `CN=wallet-provider.wct.it`,
+    certSubject: `CN=wallet-provider.wct.example.it`,
     iss: getLocalWpBaseUrl(config.wallet.port),
     jwksFilename: "wallet_provider_jwks",
     jwksPath: config.wallet.backup_storage_path,

--- a/tests/unit/status-list.unit.spec.ts
+++ b/tests/unit/status-list.unit.spec.ts
@@ -70,7 +70,7 @@ describe("createStatusListToken", () => {
 
   const walletOptions = {
     certFilename: "wallet_provider_cert",
-    certSubject: `CN=wallet-provider.wct.example`,
+    certSubject: `CN=wallet-provider.wct.example.org`,
     iss: getLocalWpBaseUrl(config.wallet.port),
     jwksFilename: "wallet_provider_jwks",
     jwksPath: config.wallet.backup_storage_path,


### PR DESCRIPTION
#### Motivation and Context

Updating the hostnames in the documentation and server configurations to use an example domain improves clarity and prevents potential misuse of real domains. This change ensures that users have a clear understanding of the intended usage without confusion.

#### How Has This Been Tested?

Changes were tested by verifying that the updated hostnames function correctly in the local development environment. All relevant unit tests were executed to ensure that the modifications did not introduce any regressions.

