### PR TITLE
Refactor default data directory structure

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -9,7 +9,7 @@ wallet_version = V1_0
 port = 3002
 
 # Storage Configuration
-wallet_attestations_storage_path = ./data/wallet/attestation
+wallet_attestations_storage_path = ./data/attestation
 credentials_storage_path = ./data/credentials # each credential within a file named using its credential type
 backup_storage_path = ./data/backup
 
@@ -22,13 +22,13 @@ port = 3003
 eidas_trusted_lists[] = [array of urls] # Optional
 
 # X.509 CA Configuration
-ca_cert_path = ./data/ca/pem # single cert or chain per each pem file
+ca_cert_path = ./data/trust_anchor/localhost # single cert or chain per each pem file
 certificate_subject="CN=localhost, O=myOrg, OU=myUnit, C=IT, ST=Roma, L=Roma, E=example@email.it"
 
 # OpenID Federation Configuration
 # Optional. List of URLs of Federation Trust Anchors to trust. If not set, no Federation TA will be trusted and federation-based tests will be skipped.
 federation_trust_anchors[] = [array of urls] 
-federation_trust_anchors_jwks_path = ./data/federation_trust_anchors/localhost # each named with the related TA name
+federation_trust_anchors_jwks_path = ./data/trust_anchor/localhost # each named with the related TA name
 
 [issuance]
 url = https://issuer.example
@@ -92,7 +92,7 @@ tls_cert_dir = ./data/backup
 [logging]
 # Logging Configuration
 log_level = INFO
-log_file = ./data/log/file
+log_file = ./data/logs/test_run.log
 log_format = [%(tag)]: %(message)
 # Optional: override the format used when writing to log_file (defaults to log_format)
 # Available placeholders: %(date) %(utc) %(tag) %(levelname) %(message)


### PR DESCRIPTION
#### Motivation and Context

This change refactors the default data directory structure in config.example.ini to simplify and standardize the storage paths. Key changes include consolidating trust anchor-related data (CA certificates and Federation JWKS) under `./data/trust_anchor/localhost`, simplifying the attestation path, and providing a more descriptive default log file name. This reorganization aims to make the project's data layout more intuitive and consistent with the expected environment setup.

JIRA Ticket: WLEO-1095
