### PR TITLE
Fix wallet attestation x5c chain

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,7 +187,7 @@ testPresentation.action((options) => {
   const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
 
   try {
-    execFileSync("pnpm", ["test:issuance", ...tests], {
+    execFileSync("pnpm", ["test:presentation", ...tests], {
       env,
       stdio: "inherit",
     });

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -140,7 +140,6 @@ const buildAttestationOptions = async (
     case ItWalletSpecsVersion.V1_3: {
       const x5c = await loadWalletProviderCertificateChain(
         wallet,
-        unitKeyPair,
         providerKeyPair,
         trust,
       );
@@ -222,7 +221,6 @@ export const loadAttestation = async (
   ensureDir(
     `${wallet.wallet_attestations_storage_path}/${wallet.wallet_version}`,
   );
-  ensureDir(wallet.backup_storage_path);
 
   const providerKeyPair = await loadJwks(
     wallet.backup_storage_path,
@@ -235,6 +233,8 @@ export const loadAttestation = async (
     trustAnchor.external_ta_url,
   );
 
+  // If an attestation already exists, try to load and validate it before deciding to create a new one.
+  // If the existing attestation cannot be loaded or is invalid/expired, it will be replaced with a new one.
   if (existsSync(attestationPath)) {
     try {
       const attestation = readFileSync(attestationPath, "utf-8");

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -15,19 +15,19 @@ import { AttestationExpiredError, TrustChainExpiredError } from "@/errors";
 import {
   buildAttestationPath,
   buildJwksPath,
+  CLOCK_SKEW_TOLERANCE_MS,
   createFederationMetadata,
   createSubordinateTrustAnchorMetadata,
   ensureDir,
-  CLOCK_SKEW_TOLERANCE_MS,
   getTrustMarks,
   hasTrustChainExpired,
   loadJsonDumps,
   loadJwks,
   loadWalletProviderCertificateChain,
+  loadWalletUnitJwksWithCert,
   partialCallbacks,
   signJwtCallback,
   validateProviderKeyPair,
-  loadWalletUnitJwksWithCert,
 } from "@/logic";
 import { getLocalWpBaseUrl } from "@/servers/wp-server";
 import { fetchExternalSubordinateStatement } from "@/trust-anchor/external-ta-registration";
@@ -224,7 +224,10 @@ export const loadAttestation = async (
   );
   ensureDir(wallet.backup_storage_path);
 
-  const providerKeyPair = await loadJwks(wallet.backup_storage_path, buildJwksPath("wallet_provider"));
+  const providerKeyPair = await loadJwks(
+    wallet.backup_storage_path,
+    buildJwksPath("wallet_provider"),
+  );
   const unitKeyPair = await loadWalletUnitJwksWithCert(wallet, providerKeyPair);
 
   const attestationPath = buildAttestationPath(

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -106,7 +106,7 @@ export const buildWpEntityConfiguration = async (
 const buildAttestationOptions = async (
   wallet: Config["wallet"],
   providerKeyPair: KeyPair,
-  unitPublicKey: KeyPair["publicKey"],
+  unitKeyPair: KeyPair,
   trustChain: [string, string],
   trust: Config["trust"],
 ): Promise<WalletAttestationOptions> => {
@@ -117,7 +117,7 @@ const buildAttestationOptions = async (
   const wpBaseUrl = getLocalWpBaseUrl(wallet.port);
   const commonOptions = {
     callbacks,
-    dpopJwkPublic: unitPublicKey,
+    dpopJwkPublic: unitKeyPair.publicKey,
     issuer: wpBaseUrl,
     walletLink: `${wpBaseUrl}/wallet`,
     walletName: wallet.wallet_name,
@@ -139,6 +139,7 @@ const buildAttestationOptions = async (
     case ItWalletSpecsVersion.V1_3: {
       const x5c = await loadWalletProviderCertificateChain(
         wallet,
+        unitKeyPair,
         providerKeyPair,
         trust,
       );
@@ -186,7 +187,7 @@ const createAttestation = async (
   const attestationOptions = await buildAttestationOptions(
     wallet,
     providerKeyPair,
-    unitKeyPair.publicKey,
+    unitKeyPair,
     [wpEntityConfiguration, taEntityConfiguration],
     trust,
   );
@@ -221,6 +222,7 @@ export const loadAttestation = async (
     `${wallet.wallet_attestations_storage_path}/${wallet.wallet_version}`,
   );
   ensureDir(wallet.backup_storage_path);
+  
 
   const [providerKeyPair, unitKeyPair] = await Promise.all([
     loadJwks(wallet.backup_storage_path, buildJwksPath("wallet_provider")),

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -27,6 +27,7 @@ import {
   partialCallbacks,
   signJwtCallback,
   validateProviderKeyPair,
+  loadWalletUnitJwksWithCert,
 } from "@/logic";
 import { getLocalWpBaseUrl } from "@/servers/wp-server";
 import { fetchExternalSubordinateStatement } from "@/trust-anchor/external-ta-registration";
@@ -145,7 +146,7 @@ const buildAttestationOptions = async (
       );
       const attestationOptions: WalletAttestationOptionsV1_3 = {
         ...commonOptions,
-        signer: { ...signerBase, method: "x5c", x5c },
+        signer: { ...signerBase, method: "x5c", trustChain, x5c },
       };
       return attestationOptions;
     }
@@ -222,12 +223,9 @@ export const loadAttestation = async (
     `${wallet.wallet_attestations_storage_path}/${wallet.wallet_version}`,
   );
   ensureDir(wallet.backup_storage_path);
-  
 
-  const [providerKeyPair, unitKeyPair] = await Promise.all([
-    loadJwks(wallet.backup_storage_path, buildJwksPath("wallet_provider")),
-    loadJwks(wallet.backup_storage_path, buildJwksPath("wallet_unit")),
-  ]);
+  const providerKeyPair = await loadJwks(wallet.backup_storage_path, buildJwksPath("wallet_provider"));
+  const unitKeyPair = await loadWalletUnitJwksWithCert(wallet, providerKeyPair);
 
   const attestationPath = buildAttestationPath(
     wallet,

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -23,7 +23,7 @@ import {
   hasTrustChainExpired,
   loadJsonDumps,
   loadJwks,
-  loadWalletProviderCertificate,
+  loadWalletProviderCertificateChain,
   partialCallbacks,
   signJwtCallback,
   validateProviderKeyPair,
@@ -108,6 +108,7 @@ const buildAttestationOptions = async (
   providerKeyPair: KeyPair,
   unitPublicKey: KeyPair["publicKey"],
   trustChain: [string, string],
+  trust: Config["trust"],
 ): Promise<WalletAttestationOptions> => {
   const callbacks = {
     ...partialCallbacks,
@@ -136,10 +137,14 @@ const buildAttestationOptions = async (
       return attestationOptions;
     }
     case ItWalletSpecsVersion.V1_3: {
-      const x5c = await loadWalletProviderCertificate(wallet, providerKeyPair);
+      const x5c = await loadWalletProviderCertificateChain(
+        wallet,
+        providerKeyPair,
+        trust,
+      );
       const attestationOptions: WalletAttestationOptionsV1_3 = {
         ...commonOptions,
-        signer: { ...signerBase, method: "x5c", trustChain, x5c },
+        signer: { ...signerBase, method: "x5c", x5c },
       };
       return attestationOptions;
     }
@@ -183,6 +188,7 @@ const createAttestation = async (
     providerKeyPair,
     unitKeyPair.publicKey,
     [wpEntityConfiguration, taEntityConfiguration],
+    trust,
   );
 
   const provider = new WalletProvider(

--- a/src/logic/federation-metadata.ts
+++ b/src/logic/federation-metadata.ts
@@ -16,6 +16,7 @@ import {
   loadJwksWithX5C,
   VALIDITY_MS,
 } from "./utils";
+import { loadWalletUnitJwksWithCert } from "./wallet-provider";
 
 export interface CreateFederationMetadataOptions {
   claims: Omit<
@@ -206,7 +207,7 @@ export interface CreateSubordinateWalletUnitMetadataOptions {
   sub: string;
   trustAnchor: Config["trust"];
   trustAnchorBaseUrl: string;
-  walletBackupStoragePath: string;
+  wallet: Config["wallet"];
 }
 
 /**
@@ -225,16 +226,21 @@ export const createSubordinateWalletUnitMetadata = async (
     options.trustAnchor.certificate_subject,
   );
 
-  const walletJwks = await loadJwks(
-    options.walletBackupStoragePath,
-    buildJwksPath("wallet_unit"),
+  const walletProviderJwks = await loadJwks(
+    options.wallet.backup_storage_path,
+    buildJwksPath("wallet_provider"),
+  );
+
+  const unitKeyPair = await loadWalletUnitJwksWithCert(
+    options.wallet,
+    walletProviderJwks,
   );
   return await createFederationMetadata({
     claims: {
       iss: options.trustAnchorBaseUrl,
       sub: options.sub,
     },
-    entityPublicJwk: walletJwks.publicKey,
+    entityPublicJwk: unitKeyPair.publicKey,
     signedJwks,
   });
 };
@@ -291,7 +297,7 @@ export async function getTrustMarks(
 
   const iat = Math.floor(Date.now() / 1000);
   const trustMarkPayload = {
-    exp: iat + (VALIDITY_MS / 1000),
+    exp: iat + VALIDITY_MS / 1000,
     iat,
     iss: trust_anchor_base_url,
     logo_uri: "https://io.italia.it/assets/img/io-it-logo-blue.svg",

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -47,6 +47,7 @@ export class CertificateBuilder {
   private _issuerKeyPair?: KeyPair;
   private _keyPair?: KeyPair;
   private _subject?: string;
+  private _validityMs = VALIDITY_MS;
 
   /**
    * Create the certificate in memory without persisting to disk.
@@ -71,6 +72,7 @@ export class CertificateBuilder {
             this._extensions,
             this._isCA,
             this._caPathLen,
+            this._validityMs,
           )
         : await createCertificateSelfSigned(
             keyPair,
@@ -78,6 +80,7 @@ export class CertificateBuilder {
             this._extensions,
             this._isCA,
             this._caPathLen,
+            this._validityMs,
           );
 
     const certPem = certificate.toString("pem");
@@ -183,6 +186,12 @@ export class CertificateBuilder {
   /** Set the subject (CN) for the certificate. */
   withSubject(subject: string): this {
     this._subject = subject;
+    return this;
+  }
+
+  /** Override the certificate validity window (default: VALIDITY_MS = 1 year). */
+  withValidity(ms: number): this {
+    this._validityMs = ms;
     return this;
   }
 
@@ -310,6 +319,7 @@ async function createCertificateIssuerSigned(
   extraExtensions: x509.Extension[] = [],
   isCA = false,
   caPathLen?: number,
+  validityMs = VALIDITY_MS,
 ): Promise<x509.X509Certificate> {
   const signingAlgorithm = {
     hash: "SHA-256",
@@ -334,7 +344,7 @@ async function createCertificateIssuerSigned(
   );
 
   const notBefore = new Date();
-  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
+  const notAfter = new Date(notBefore.getTime() + validityMs);
 
   const cert = await x509.X509CertificateGenerator.create({
     extensions: [
@@ -350,6 +360,7 @@ async function createCertificateIssuerSigned(
         false,
       ),
       await x509.SubjectKeyIdentifierExtension.create(publicKey),
+      await x509.AuthorityKeyIdentifierExtension.create(issuerCertificate, false),
       ...extraExtensions,
     ],
     issuer: issuerCertificate.subject,
@@ -376,6 +387,7 @@ async function createCertificateSelfSigned(
   extraExtensions: x509.Extension[] = [],
   isCA = false,
   caPathLen?: number,
+  validityMs = VALIDITY_MS,
 ): Promise<x509.X509Certificate> {
   const signingAlgorithm = {
     hash: "SHA-256",
@@ -402,7 +414,7 @@ async function createCertificateSelfSigned(
   const keys = { privateKey, publicKey };
 
   const notBefore = new Date();
-  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
+  const notAfter = new Date(notBefore.getTime() + validityMs);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
     extensions: [
       new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -74,14 +74,24 @@ export class CertificateBuilder {
             this._caPathLen,
             this._validityMs,
           )
-        : await createCertificateSelfSigned(
-            keyPair,
-            subject,
-            this._extensions,
-            this._isCA,
-            this._caPathLen,
-            this._validityMs,
-          );
+        : this._issuerKeyPair
+          ? await createCertificateSelfIssued(
+              keyPair,
+              subject,
+              this._issuerKeyPair,
+              this._extensions,
+              this._isCA,
+              this._caPathLen,
+              this._validityMs,
+            )
+          : await createCertificateSelfSigned(
+              keyPair,
+              subject,
+              this._extensions,
+              this._isCA,
+              this._caPathLen,
+              this._validityMs,
+            );
 
     const certPem = certificate.toString("pem");
     const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
@@ -139,10 +149,18 @@ export class CertificateBuilder {
     return { ...result, certPath };
   }
 
-  /** Mark the certificate as self-signed (default behaviour). */
-  selfSigned(): this {
+  /**
+   * Mark the certificate as self-issued (issuer DN = subject DN).
+   *
+   * - No argument: the subject key pair also signs the certificate (truly self-signed).
+   * - With `signerKeyPair`: the certificate is signed by `signerKeyPair` while the
+   *   public key in the certificate comes from {@link withKeyPair}. This produces a
+   *   self-issued Protocol Certificate per IT-Wallet §6.14.2 — the federation entity
+   *   key (Key A) certifies a separate protocol key (Key B).
+   */
+  selfIssued(signerKeyPair?: KeyPair): this {
     this._issuerCert = undefined;
-    this._issuerKeyPair = undefined;
+    this._issuerKeyPair = signerKeyPair;
     return this;
   }
 
@@ -277,7 +295,7 @@ export async function loadCertificate(
   const result = await new CertificateBuilder()
     .withSubject(subject)
     .withKeyPair(keyPair)
-    .selfSigned()
+    .selfIssued()
     .loadOrCreate(certPath, filename);
   return result.certDerBase64;
 }
@@ -300,7 +318,7 @@ export async function loadOrCreateCertificateWithKey(
   const result = await new CertificateBuilder()
     .withSubject(subject)
     .withGeneratedKey()
-    .selfSigned()
+    .selfIssued()
     .withExtensions(extraExtensions)
     .loadOrCreate(dir, baseName);
   return {
@@ -374,6 +392,71 @@ async function createCertificateIssuerSigned(
   });
 
   return cert;
+}
+
+// Self-issued: issuer DN = subject DN, signed by a (potentially different) key pair.
+async function createCertificateSelfIssued(
+  keyPair: KeyPair,
+  subject: string,
+  signerKeyPair: KeyPair,
+  extraExtensions: x509.Extension[] = [],
+  isCA = false,
+  caPathLen?: number,
+  validityMs = VALIDITY_MS,
+): Promise<x509.X509Certificate> {
+  const signingAlgorithm = { hash: "SHA-256", name: "ECDSA", namedCurve: "P-256" };
+
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    keyPair.publicKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"],
+  );
+  const signerPublicKey = await crypto.subtle.importKey(
+    "jwk",
+    signerKeyPair.publicKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"],
+  );
+  const signingKey = await crypto.subtle.importKey(
+    "jwk",
+    signerKeyPair.privateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"],
+  );
+
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore.getTime() + validityMs);
+
+  return x509.X509CertificateGenerator.create({
+    extensions: [
+      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.KeyUsagesExtension(
+        isCA
+          ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign
+          : x509.KeyUsageFlags.digitalSignature,
+        true,
+      ),
+      new x509.ExtendedKeyUsageExtension(
+        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
+        false,
+      ),
+      await x509.SubjectKeyIdentifierExtension.create(publicKey),
+      await x509.AuthorityKeyIdentifierExtension.create(signerPublicKey),
+      ...extraExtensions,
+    ],
+    issuer: subject,
+    notAfter,
+    notBefore,
+    publicKey,
+    serialNumber: crypto.randomUUID().replace(/-/g, ""),
+    signingAlgorithm,
+    signingKey,
+    subject,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -366,7 +366,11 @@ async function createCertificateIssuerSigned(
 
   const cert = await x509.X509CertificateGenerator.create({
     extensions: [
-      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.BasicConstraintsExtension(
+        isCA,
+        isCA ? caPathLen : undefined,
+        true,
+      ),
       new x509.KeyUsagesExtension(
         isCA
           ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign
@@ -378,7 +382,10 @@ async function createCertificateIssuerSigned(
         false,
       ),
       await x509.SubjectKeyIdentifierExtension.create(publicKey),
-      await x509.AuthorityKeyIdentifierExtension.create(issuerCertificate, false),
+      await x509.AuthorityKeyIdentifierExtension.create(
+        issuerCertificate,
+        false,
+      ),
       ...extraExtensions,
     ],
     issuer: issuerCertificate.subject,
@@ -404,7 +411,11 @@ async function createCertificateSelfIssued(
   caPathLen?: number,
   validityMs = VALIDITY_MS,
 ): Promise<x509.X509Certificate> {
-  const signingAlgorithm = { hash: "SHA-256", name: "ECDSA", namedCurve: "P-256" };
+  const signingAlgorithm = {
+    hash: "SHA-256",
+    name: "ECDSA",
+    namedCurve: "P-256",
+  };
 
   const publicKey = await crypto.subtle.importKey(
     "jwk",
@@ -433,7 +444,11 @@ async function createCertificateSelfIssued(
 
   return x509.X509CertificateGenerator.create({
     extensions: [
-      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.BasicConstraintsExtension(
+        isCA,
+        isCA ? caPathLen : undefined,
+        true,
+      ),
       new x509.KeyUsagesExtension(
         isCA
           ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign
@@ -500,7 +515,11 @@ async function createCertificateSelfSigned(
   const notAfter = new Date(notBefore.getTime() + validityMs);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
     extensions: [
-      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.BasicConstraintsExtension(
+        isCA,
+        isCA ? caPathLen : undefined,
+        true,
+      ),
       new x509.KeyUsagesExtension(
         isCA
           ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -11,27 +11,27 @@ import path from "node:path";
 import { KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
-import { ensureDir, CLOCK_SKEW_TOLERANCE_MS, VALIDITY_MS } from "./utils";
+import { CLOCK_SKEW_TOLERANCE_MS, ensureDir, VALIDITY_MS } from "./utils";
 
 // ---------------------------------------------------------------------------
 // Result type
 // ---------------------------------------------------------------------------
 
 export interface CertificateResult {
-  /** The X.509 certificate object. */
-  certificate: x509.X509Certificate;
   /** DER-encoded certificate, base64-encoded — suitable for x5c arrays. */
   certDerBase64: string;
-  /** The certificate in PEM format. */
-  certPem: string;
+  /** The X.509 certificate object. */
+  certificate: x509.X509Certificate;
   /** Absolute path of the persisted certificate file (set by loadOrCreate). */
   certPath?: string;
+  /** The certificate in PEM format. */
+  certPem: string;
   /** The key pair associated with the certificate (when provided or generated). */
   keyPair?: KeyPair;
-  /** Private key in PKCS#8 PEM format (set when key is generated). */
-  keyPem?: string;
   /** Absolute path of the persisted key file (set by loadOrCreate with generated key). */
   keyPath?: string;
+  /** Private key in PKCS#8 PEM format (set when key is generated). */
+  keyPem?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,55 +39,12 @@ export interface CertificateResult {
 // ---------------------------------------------------------------------------
 
 export class CertificateBuilder {
-  private _subject?: string;
-  private _keyPair?: KeyPair;
+  private _extensions: x509.Extension[] = [];
   private _generateKey = false;
   private _issuerCert?: x509.X509Certificate;
   private _issuerKeyPair?: KeyPair;
-  private _extensions: x509.Extension[] = [];
-
-  /** Set the subject (CN) for the certificate. */
-  withSubject(subject: string): this {
-    this._subject = subject;
-    return this;
-  }
-
-  /** Provide an existing key pair. Mutually exclusive with withGeneratedKey(). */
-  withKeyPair(keyPair: KeyPair): this {
-    this._keyPair = keyPair;
-    this._generateKey = false;
-    return this;
-  }
-
-  /** Auto-generate a new ECDSA P-256 key pair. Mutually exclusive with withKeyPair(). */
-  withGeneratedKey(): this {
-    this._generateKey = true;
-    this._keyPair = undefined;
-    return this;
-  }
-
-  /** Mark the certificate as self-signed (default behaviour). */
-  selfSigned(): this {
-    this._issuerCert = undefined;
-    this._issuerKeyPair = undefined;
-    return this;
-  }
-
-  /** Sign the certificate with an issuer (CA-signed). */
-  signedBy(
-    issuerCertificate: x509.X509Certificate,
-    issuerKeyPair: KeyPair,
-  ): this {
-    this._issuerCert = issuerCertificate;
-    this._issuerKeyPair = issuerKeyPair;
-    return this;
-  }
-
-  /** Append extra X.509 extensions to the certificate. */
-  withExtensions(extensions: x509.Extension[]): this {
-    this._extensions = extensions;
-    return this;
-  }
+  private _keyPair?: KeyPair;
+  private _subject?: string;
 
   /**
    * Create the certificate in memory without persisting to disk.
@@ -111,11 +68,7 @@ export class CertificateBuilder {
             this._issuerKeyPair.privateKey,
             this._extensions,
           )
-        : await createCertificateSelfSigned(
-            keyPair,
-            subject,
-            this._extensions,
-          );
+        : await createCertificateSelfSigned(keyPair, subject, this._extensions);
 
     const certPem = certificate.toString("pem");
     const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
@@ -132,7 +85,7 @@ export class CertificateBuilder {
       keyPem = await privateKeyToPem(privateKey);
     }
 
-    return { certificate, certDerBase64, certPem, keyPair, keyPem };
+    return { certDerBase64, certificate, certPem, keyPair, keyPem };
   }
 
   /**
@@ -173,6 +126,49 @@ export class CertificateBuilder {
     return { ...result, certPath };
   }
 
+  /** Mark the certificate as self-signed (default behaviour). */
+  selfSigned(): this {
+    this._issuerCert = undefined;
+    this._issuerKeyPair = undefined;
+    return this;
+  }
+
+  /** Sign the certificate with an issuer (CA-signed). */
+  signedBy(
+    issuerCertificate: x509.X509Certificate,
+    issuerKeyPair: KeyPair,
+  ): this {
+    this._issuerCert = issuerCertificate;
+    this._issuerKeyPair = issuerKeyPair;
+    return this;
+  }
+
+  /** Append extra X.509 extensions to the certificate. */
+  withExtensions(extensions: x509.Extension[]): this {
+    this._extensions = extensions;
+    return this;
+  }
+
+  /** Auto-generate a new ECDSA P-256 key pair. Mutually exclusive with withKeyPair(). */
+  withGeneratedKey(): this {
+    this._generateKey = true;
+    this._keyPair = undefined;
+    return this;
+  }
+
+  /** Provide an existing key pair. Mutually exclusive with withGeneratedKey(). */
+  withKeyPair(keyPair: KeyPair): this {
+    this._keyPair = keyPair;
+    this._generateKey = false;
+    return this;
+  }
+
+  /** Set the subject (CN) for the certificate. */
+  withSubject(subject: string): this {
+    this._subject = subject;
+    return this;
+  }
+
   // -----------------------------------------------------------------------
   // Private helpers
   // -----------------------------------------------------------------------
@@ -191,14 +187,12 @@ export class CertificateBuilder {
         rmSync(filePath);
         return undefined;
       }
-      const certDerBase64 = Buffer.from(certificate.rawData).toString(
-        "base64",
-      );
+      const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
       return {
-        certificate,
         certDerBase64,
-        certPem,
+        certificate,
         certPath: filePath,
+        certPem,
         keyPair: this._keyPair,
       };
     } catch {
@@ -223,16 +217,14 @@ export class CertificateBuilder {
         rmSync(keyPath);
         return undefined;
       }
-      const certDerBase64 = Buffer.from(certificate.rawData).toString(
-        "base64",
-      );
+      const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
       return {
-        certificate,
         certDerBase64,
-        certPem,
+        certificate,
         certPath,
-        keyPem,
+        certPem,
         keyPath,
+        keyPem,
       };
     } catch {
       return undefined;
@@ -244,56 +236,53 @@ export class CertificateBuilder {
 // Low-level certificate creation (used by CertificateBuilder)
 // ---------------------------------------------------------------------------
 
-async function createCertificateSelfSigned(
+export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
+  const certificate =
+    typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
+  return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
+}
+
+export async function loadCertificate(
+  certPath: string,
+  filename: string,
   keyPair: KeyPair,
   subject: string,
+): Promise<string> {
+  const result = await new CertificateBuilder()
+    .withSubject(subject)
+    .withKeyPair(keyPair)
+    .selfSigned()
+    .loadOrCreate(certPath, filename);
+  return result.certDerBase64;
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+export async function loadOrCreateCertificateWithKey(
+  dir: string,
+  baseName: string,
+  subject: string,
   extraExtensions: x509.Extension[] = [],
-): Promise<x509.X509Certificate> {
-  const signingAlgorithm = {
-    hash: "SHA-256",
-    name: "ECDSA",
-    namedCurve: "P-256",
+): Promise<{
+  certPath: string;
+  certPem: string;
+  keyPath: string;
+  keyPem: string;
+}> {
+  const result = await new CertificateBuilder()
+    .withSubject(subject)
+    .withGeneratedKey()
+    .selfSigned()
+    .withExtensions(extraExtensions)
+    .loadOrCreate(dir, baseName);
+  return {
+    certPath: result.certPath!,
+    certPem: result.certPem,
+    keyPath: result.keyPath!,
+    keyPem: result.keyPem!,
   };
-
-  const privateKey = await crypto.subtle.importKey(
-    "jwk",
-    keyPair.privateKey,
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign"],
-  );
-
-  const publicKey = await crypto.subtle.importKey(
-    "jwk",
-    keyPair.publicKey,
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["verify"],
-  );
-
-  const keys = { privateKey, publicKey };
-
-  const notBefore = new Date();
-  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
-  const cert = await x509.X509CertificateGenerator.createSelfSigned({
-    extensions: [
-      new x509.BasicConstraintsExtension(false, undefined, true),
-      new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
-      new x509.ExtendedKeyUsageExtension(
-        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
-        false,
-      ),
-      await x509.SubjectKeyIdentifierExtension.create(publicKey),
-      ...extraExtensions,
-    ],
-    keys,
-    name: subject,
-    notAfter,
-    notBefore,
-    signingAlgorithm,
-  });
-
-  return cert;
 }
 
 async function createCertificateIssuerSigned(
@@ -353,13 +342,60 @@ async function createCertificateIssuerSigned(
 }
 
 // ---------------------------------------------------------------------------
-// Utility
+// Legacy wrappers — delegate to CertificateBuilder for backward compatibility.
+// Prefer CertificateBuilder directly in new code.
 // ---------------------------------------------------------------------------
 
-export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
-  const certificate =
-    typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
-  return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
+async function createCertificateSelfSigned(
+  keyPair: KeyPair,
+  subject: string,
+  extraExtensions: x509.Extension[] = [],
+): Promise<x509.X509Certificate> {
+  const signingAlgorithm = {
+    hash: "SHA-256",
+    name: "ECDSA",
+    namedCurve: "P-256",
+  };
+
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    keyPair.privateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"],
+  );
+
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    keyPair.publicKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"],
+  );
+
+  const keys = { privateKey, publicKey };
+
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    extensions: [
+      new x509.BasicConstraintsExtension(false, undefined, true),
+      new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+      new x509.ExtendedKeyUsageExtension(
+        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
+        false,
+      ),
+      await x509.SubjectKeyIdentifierExtension.create(publicKey),
+      ...extraExtensions,
+    ],
+    keys,
+    name: subject,
+    notAfter,
+    notBefore,
+    signingAlgorithm,
+  });
+
+  return cert;
 }
 
 async function privateKeyToPem(key: CryptoKey): Promise<string> {
@@ -367,48 +403,4 @@ async function privateKeyToPem(key: CryptoKey): Promise<string> {
   const b64 = Buffer.from(exported).toString("base64");
   const lines = b64.match(/.{1,64}/g)!.join("\n");
   return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
-}
-
-// ---------------------------------------------------------------------------
-// Legacy wrappers — delegate to CertificateBuilder for backward compatibility.
-// Prefer CertificateBuilder directly in new code.
-// ---------------------------------------------------------------------------
-
-export async function loadCertificate(
-  certPath: string,
-  filename: string,
-  keyPair: KeyPair,
-  subject: string,
-): Promise<string> {
-  const result = await new CertificateBuilder()
-    .withSubject(subject)
-    .withKeyPair(keyPair)
-    .selfSigned()
-    .loadOrCreate(certPath, filename);
-  return result.certDerBase64;
-}
-
-export async function loadOrCreateCertificateWithKey(
-  dir: string,
-  baseName: string,
-  subject: string,
-  extraExtensions: x509.Extension[] = [],
-): Promise<{
-  certPath: string;
-  certPem: string;
-  keyPath: string;
-  keyPem: string;
-}> {
-  const result = await new CertificateBuilder()
-    .withSubject(subject)
-    .withGeneratedKey()
-    .selfSigned()
-    .withExtensions(extraExtensions)
-    .loadOrCreate(dir, baseName);
-  return {
-    certPath: result.certPath!,
-    certPem: result.certPem,
-    keyPath: result.keyPath!,
-    keyPem: result.keyPem!,
-  };
 }

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -8,94 +8,247 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-import { CertificateExpiredError } from "@/errors";
-import { Config, KeyPair } from "@/types";
+import { KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
 import { ensureDir, CLOCK_SKEW_TOLERANCE_MS, VALIDITY_MS } from "./utils";
 
-/**
- * Creates a self-signed X.509 certificate and saves it to a file in PEM format.
- *
- * @param fileName The name of the file to save the certificate to.
- * @param keyPair The key pair to use for signing the certificate.
- * @param subject The subject name for the certificate.
- * @returns A promise that resolves to the base64-encoded DER representation of the certificate.
- */
-export async function createAndSaveCertificate(
-  fileName: string,
-  keyPair: KeyPair,
-  subject: string,
-): Promise<string> {
-  const certificate = await createCertificate(keyPair, subject);
-  writeFileSync(fileName, certificate.toString("pem"));
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
 
-  // Return DER string representation of the certificate
-  return Buffer.from(certificate.rawData).toString("base64");
-}
-
-/**
- * Generates a key pair, creates a self-signed X.509 certificate, and writes both
- * the cert and private key to collision-resistant PEM files inside `dir`.
- *
- * The key file is written with mode 0o600 (owner read/write only) to prevent
- * accidental exposure of private key material.
- *
- * @param dir Directory to write the files into (created if absent).
- * @param baseName Base filename (without extension) for the cert and key files.
- * @param subject The subject / CN for the certificate.
- * @param extraExtensions Additional X.509 extensions appended to the default set.
- * @returns The cert PEM, key PEM, and absolute paths of the written cert and key files.
- */
-export async function createAndSaveCertificateWithKey(
-  dir: string,
-  baseName: string,
-  subject: string,
-  extraExtensions: x509.Extension[] = [],
-): Promise<{
-  certPath: string;
+export interface CertificateResult {
+  /** The X.509 certificate object. */
+  certificate: x509.X509Certificate;
+  /** DER-encoded certificate, base64-encoded — suitable for x5c arrays. */
+  certDerBase64: string;
+  /** The certificate in PEM format. */
   certPem: string;
-  keyPath: string;
-  keyPem: string;
-}> {
-  mkdirSync(dir, { recursive: true });
-
-  const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
-  const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
-
-  const keyPair = await createKeys();
-  const cert = await createCertificate(keyPair, subject, extraExtensions);
-  const certPem = cert.toString("pem");
-
-  const privateKey = await crypto.subtle.importKey(
-    "jwk",
-    keyPair.privateKey,
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign"],
-  );
-  const keyPem = await privateKeyToPem(privateKey);
-
-  writeFileSync(certPath, certPem);
-  writeFileSync(keyPath, keyPem, { mode: 0o600 });
-
-  return { certPath, certPem, keyPath, keyPem };
+  /** Absolute path of the persisted certificate file (set by loadOrCreate). */
+  certPath?: string;
+  /** The key pair associated with the certificate (when provided or generated). */
+  keyPair?: KeyPair;
+  /** Private key in PKCS#8 PEM format (set when key is generated). */
+  keyPem?: string;
+  /** Absolute path of the persisted key file (set by loadOrCreate with generated key). */
+  keyPath?: string;
 }
 
-/**
- * Creates a self-signed X.509 certificate.
- *
- * @param keyPair The key pair to use for signing the certificate.
- * @param subject The subject name for the certificate.
- * @param extraExtensions Additional X.509 extensions appended to the default set.
- * @returns A promise that resolves to the certificate object.
- */
-export async function createCertificate(
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export class CertificateBuilder {
+  private _subject?: string;
+  private _keyPair?: KeyPair;
+  private _generateKey = false;
+  private _issuerCert?: x509.X509Certificate;
+  private _issuerKeyPair?: KeyPair;
+  private _extensions: x509.Extension[] = [];
+
+  /** Set the subject (CN) for the certificate. */
+  withSubject(subject: string): this {
+    this._subject = subject;
+    return this;
+  }
+
+  /** Provide an existing key pair. Mutually exclusive with withGeneratedKey(). */
+  withKeyPair(keyPair: KeyPair): this {
+    this._keyPair = keyPair;
+    this._generateKey = false;
+    return this;
+  }
+
+  /** Auto-generate a new ECDSA P-256 key pair. Mutually exclusive with withKeyPair(). */
+  withGeneratedKey(): this {
+    this._generateKey = true;
+    this._keyPair = undefined;
+    return this;
+  }
+
+  /** Mark the certificate as self-signed (default behaviour). */
+  selfSigned(): this {
+    this._issuerCert = undefined;
+    this._issuerKeyPair = undefined;
+    return this;
+  }
+
+  /** Sign the certificate with an issuer (CA-signed). */
+  signedBy(
+    issuerCertificate: x509.X509Certificate,
+    issuerKeyPair: KeyPair,
+  ): this {
+    this._issuerCert = issuerCertificate;
+    this._issuerKeyPair = issuerKeyPair;
+    return this;
+  }
+
+  /** Append extra X.509 extensions to the certificate. */
+  withExtensions(extensions: x509.Extension[]): this {
+    this._extensions = extensions;
+    return this;
+  }
+
+  /**
+   * Create the certificate in memory without persisting to disk.
+   */
+  async create(): Promise<CertificateResult> {
+    const subject = this._subject;
+    if (!subject) throw new Error("Subject is required: call withSubject()");
+
+    const keyPair = this._generateKey ? await createKeys() : this._keyPair;
+    if (!keyPair)
+      throw new Error(
+        "Key pair is required: call withKeyPair() or withGeneratedKey()",
+      );
+
+    const certificate =
+      this._issuerCert && this._issuerKeyPair
+        ? await createCertificateIssuerSigned(
+            keyPair,
+            subject,
+            this._issuerCert,
+            this._issuerKeyPair.privateKey,
+            this._extensions,
+          )
+        : await createCertificateSelfSigned(
+            keyPair,
+            subject,
+            this._extensions,
+          );
+
+    const certPem = certificate.toString("pem");
+    const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
+
+    let keyPem: string | undefined;
+    if (this._generateKey) {
+      const privateKey = await crypto.subtle.importKey(
+        "jwk",
+        keyPair.privateKey,
+        { name: "ECDSA", namedCurve: "P-256" },
+        true,
+        ["sign"],
+      );
+      keyPem = await privateKeyToPem(privateKey);
+    }
+
+    return { certificate, certDerBase64, certPem, keyPair, keyPem };
+  }
+
+  /**
+   * Load the certificate from disk. If not found or expired, create and persist
+   * it automatically.
+   *
+   * When {@link withGeneratedKey} is active, files are named
+   * `${fileName}.cert.pem` and `${fileName}.key.pem`.
+   * Otherwise the certificate file is stored as `${fileName}` (no extension added).
+   */
+  async loadOrCreate(
+    dir: string,
+    fileName: string,
+  ): Promise<CertificateResult> {
+    const dirCreated = ensureDir(dir);
+
+    if (!dirCreated) {
+      const loaded = this._generateKey
+        ? this.tryLoadWithKey(dir, fileName)
+        : this.tryLoadCertOnly(dir, fileName);
+
+      if (loaded) return loaded;
+    }
+
+    const result = await this.create();
+
+    if (this._generateKey) {
+      mkdirSync(dir, { recursive: true });
+      const certPath = path.resolve(path.join(dir, `${fileName}.cert.pem`));
+      const keyPath = path.resolve(path.join(dir, `${fileName}.key.pem`));
+      writeFileSync(certPath, result.certPem);
+      writeFileSync(keyPath, result.keyPem!, { mode: 0o600 });
+      return { ...result, certPath, keyPath };
+    }
+
+    const certPath = path.resolve(path.join(dir, fileName));
+    writeFileSync(certPath, result.certPem);
+    return { ...result, certPath };
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private tryLoadCertOnly(
+    dir: string,
+    fileName: string,
+  ): CertificateResult | undefined {
+    const filePath = path.resolve(path.join(dir, fileName));
+    if (!existsSync(filePath)) return undefined;
+
+    try {
+      const certPem = readFileSync(filePath, "utf-8");
+      const certificate = new x509.X509Certificate(certPem);
+      if (hasX509CertificateExpired(certificate)) {
+        rmSync(filePath);
+        return undefined;
+      }
+      const certDerBase64 = Buffer.from(certificate.rawData).toString(
+        "base64",
+      );
+      return {
+        certificate,
+        certDerBase64,
+        certPem,
+        certPath: filePath,
+        keyPair: this._keyPair,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  private tryLoadWithKey(
+    dir: string,
+    baseName: string,
+  ): CertificateResult | undefined {
+    const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
+    const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
+    if (!existsSync(certPath) || !existsSync(keyPath)) return undefined;
+
+    try {
+      const certPem = readFileSync(certPath, "utf-8");
+      const keyPem = readFileSync(keyPath, "utf-8");
+      const certificate = new x509.X509Certificate(certPem);
+      if (hasX509CertificateExpired(certificate)) {
+        rmSync(certPath);
+        rmSync(keyPath);
+        return undefined;
+      }
+      const certDerBase64 = Buffer.from(certificate.rawData).toString(
+        "base64",
+      );
+      return {
+        certificate,
+        certDerBase64,
+        certPem,
+        certPath,
+        keyPem,
+        keyPath,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level certificate creation (used by CertificateBuilder)
+// ---------------------------------------------------------------------------
+
+async function createCertificateSelfSigned(
   keyPair: KeyPair,
   subject: string,
   extraExtensions: x509.Extension[] = [],
 ): Promise<x509.X509Certificate> {
-  // Import JWK -> CryptoKey
   const signingAlgorithm = {
     hash: "SHA-256",
     name: "ECDSA",
@@ -120,7 +273,6 @@ export async function createCertificate(
 
   const keys = { privateKey, publicKey };
 
-  // Create self-signed cert (X.509)
   const notBefore = new Date();
   const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
@@ -144,72 +296,98 @@ export async function createCertificate(
   return cert;
 }
 
+async function createCertificateIssuerSigned(
+  keyPair: KeyPair,
+  subject: string,
+  issuerCertificate: x509.X509Certificate,
+  issuerPrivateKey: JsonWebKey,
+  extraExtensions: x509.Extension[] = [],
+): Promise<x509.X509Certificate> {
+  const signingAlgorithm = {
+    hash: "SHA-256",
+    name: "ECDSA",
+    namedCurve: "P-256",
+  };
+
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    keyPair.publicKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"],
+  );
+
+  const signingKey = await crypto.subtle.importKey(
+    "jwk",
+    issuerPrivateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"],
+  );
+
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
+
+  const cert = await x509.X509CertificateGenerator.create({
+    extensions: [
+      new x509.BasicConstraintsExtension(false, undefined, true),
+      new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+      new x509.ExtendedKeyUsageExtension(
+        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
+        false,
+      ),
+      await x509.SubjectKeyIdentifierExtension.create(publicKey),
+      ...extraExtensions,
+    ],
+    issuer: issuerCertificate.subject,
+    notAfter,
+    notBefore,
+    publicKey,
+    serialNumber: crypto.randomUUID().replace(/-/g, ""),
+    signingAlgorithm,
+    signingKey,
+    subject,
+  });
+
+  return cert;
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
 export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
   return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
 }
 
-/**
- * Loads a certificate from a file, or creates and saves it if it doesn't exist.
- *
- * @param certPath The directory path where the certificate is stored.
- * @param filename The name of the certificate file.
- * @param keyPair The key pair to use if creating a new certificate.
- * @param subject The subject name to use if creating a new certificate.
- * @returns A promise that resolves to the base64-DER encoded certificate
- *          (DER-encoded X.509, base64-encoded, no PEM headers) — suitable
- *          for use in an x5c header array per RFC 7517 §4.7.
- */
+async function privateKeyToPem(key: CryptoKey): Promise<string> {
+  const exported = await crypto.subtle.exportKey("pkcs8", key);
+  const b64 = Buffer.from(exported).toString("base64");
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy wrappers — delegate to CertificateBuilder for backward compatibility.
+// Prefer CertificateBuilder directly in new code.
+// ---------------------------------------------------------------------------
+
 export async function loadCertificate(
   certPath: string,
   filename: string,
   keyPair: KeyPair,
   subject: string,
 ): Promise<string> {
-  const dirCreated = ensureDir(certPath);
-
-  if (!dirCreated) {
-    try {
-      const certPem = readFileSync(`${certPath}/${filename}`, "utf-8");
-      const certDerBase64 = certPem
-        .replace("-----BEGIN CERTIFICATE-----", "")
-        .replace("-----END CERTIFICATE-----", "")
-        .replace(/\s+/g, "")
-        .trim();
-
-      if (hasX509CertificateExpired(certDerBase64))
-        throw new CertificateExpiredError(
-          "Certificate has expired and has to be regenerated",
-        );
-
-      return certDerBase64;
-    } catch {
-      /* fall through to generate */
-    }
-  }
-
-  return await createAndSaveCertificate(
-    `${certPath}/${filename}`,
-    keyPair,
-    subject,
-  );
+  const result = await new CertificateBuilder()
+    .withSubject(subject)
+    .withKeyPair(keyPair)
+    .selfSigned()
+    .loadOrCreate(certPath, filename);
+  return result.certDerBase64;
 }
 
-/**
- * Loads an existing cert/key pair from `dir` if one is present, otherwise
- * creates a new one via {@link createAndSaveCertificateWithKey}.
- *
- * File discovery: looks for `${baseName}.cert.pem` and `${baseName}.key.pem` in `dir`.
- * Falls through to creation if the directory is absent, those files are missing,
- * or either file cannot be read.
- *
- * @param dir Directory to search or write files into.
- * @param baseName Base filename (without extension) for the cert and key files.
- * @param subject The subject / CN — used only when creation is needed.
- * @param extraExtensions Additional X.509 extensions — used only when creation is needed.
- * @returns The cert PEM, key PEM, and absolute paths of the cert and key files.
- */
 export async function loadOrCreateCertificateWithKey(
   dir: string,
   baseName: string,
@@ -221,42 +399,16 @@ export async function loadOrCreateCertificateWithKey(
   keyPath: string;
   keyPem: string;
 }> {
-  const dirCreated = ensureDir(dir);
-
-  if (!dirCreated) {
-    const certPath = path.resolve(path.join(dir, `${baseName}.cert.pem`));
-    const keyPath = path.resolve(path.join(dir, `${baseName}.key.pem`));
-    if (existsSync(certPath) && existsSync(keyPath)) {
-      const certPem = readFileSync(certPath, "utf-8");
-      const keyPem = readFileSync(keyPath, "utf-8");
-
-      const cert = new x509.X509Certificate(certPem);
-      if (hasX509CertificateExpired(cert)) {
-        rmSync(certPath);
-        rmSync(keyPath);
-      } else {
-        return { certPath, certPem, keyPath, keyPem };
-      }
-    }
-  }
-
-  return createAndSaveCertificateWithKey(
-    dir,
-    baseName,
-    subject,
-    extraExtensions,
-  );
-}
-
-/**
- * Exports a private CryptoKey to PKCS#8 PEM format.
- *
- * @param key The private CryptoKey to export.
- * @returns The key in PKCS#8 PEM format.
- */
-async function privateKeyToPem(key: CryptoKey): Promise<string> {
-  const exported = await crypto.subtle.exportKey("pkcs8", key);
-  const b64 = Buffer.from(exported).toString("base64");
-  const lines = b64.match(/.{1,64}/g)!.join("\n");
-  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+  const result = await new CertificateBuilder()
+    .withSubject(subject)
+    .withGeneratedKey()
+    .selfSigned()
+    .withExtensions(extraExtensions)
+    .loadOrCreate(dir, baseName);
+  return {
+    certPath: result.certPath!,
+    certPem: result.certPem,
+    keyPath: result.keyPath!,
+    keyPem: result.keyPem!,
+  };
 }

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -39,8 +39,10 @@ export interface CertificateResult {
 // ---------------------------------------------------------------------------
 
 export class CertificateBuilder {
+  private _caPathLen?: number;
   private _extensions: x509.Extension[] = [];
   private _generateKey = false;
+  private _isCA = false;
   private _issuerCert?: x509.X509Certificate;
   private _issuerKeyPair?: KeyPair;
   private _keyPair?: KeyPair;
@@ -67,8 +69,16 @@ export class CertificateBuilder {
             this._issuerCert,
             this._issuerKeyPair.privateKey,
             this._extensions,
+            this._isCA,
+            this._caPathLen,
           )
-        : await createCertificateSelfSigned(keyPair, subject, this._extensions);
+        : await createCertificateSelfSigned(
+            keyPair,
+            subject,
+            this._extensions,
+            this._isCA,
+            this._caPathLen,
+          );
 
     const certPem = certificate.toString("pem");
     const certDerBase64 = Buffer.from(certificate.rawData).toString("base64");
@@ -140,6 +150,13 @@ export class CertificateBuilder {
   ): this {
     this._issuerCert = issuerCertificate;
     this._issuerKeyPair = issuerKeyPair;
+    return this;
+  }
+
+  /** Mark this certificate as a CA (BasicConstraints cA=TRUE, KeyUsage keyCertSign|cRLSign). */
+  withCaCapability(pathLen?: number): this {
+    this._isCA = true;
+    this._caPathLen = pathLen;
     return this;
   }
 
@@ -291,6 +308,8 @@ async function createCertificateIssuerSigned(
   issuerCertificate: x509.X509Certificate,
   issuerPrivateKey: JsonWebKey,
   extraExtensions: x509.Extension[] = [],
+  isCA = false,
+  caPathLen?: number,
 ): Promise<x509.X509Certificate> {
   const signingAlgorithm = {
     hash: "SHA-256",
@@ -319,8 +338,13 @@ async function createCertificateIssuerSigned(
 
   const cert = await x509.X509CertificateGenerator.create({
     extensions: [
-      new x509.BasicConstraintsExtension(false, undefined, true),
-      new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.KeyUsagesExtension(
+        isCA
+          ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign
+          : x509.KeyUsageFlags.digitalSignature,
+        true,
+      ),
       new x509.ExtendedKeyUsageExtension(
         [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
         false,
@@ -350,6 +374,8 @@ async function createCertificateSelfSigned(
   keyPair: KeyPair,
   subject: string,
   extraExtensions: x509.Extension[] = [],
+  isCA = false,
+  caPathLen?: number,
 ): Promise<x509.X509Certificate> {
   const signingAlgorithm = {
     hash: "SHA-256",
@@ -379,8 +405,13 @@ async function createCertificateSelfSigned(
   const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
   const cert = await x509.X509CertificateGenerator.createSelfSigned({
     extensions: [
-      new x509.BasicConstraintsExtension(false, undefined, true),
-      new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+      new x509.BasicConstraintsExtension(isCA, isCA ? caPathLen : undefined, true),
+      new x509.KeyUsagesExtension(
+        isCA
+          ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign
+          : x509.KeyUsageFlags.digitalSignature,
+        true,
+      ),
       new x509.ExtendedKeyUsageExtension(
         [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
         false,

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -25,6 +25,7 @@ import {
 
 export const CLOCK_SKEW_TOLERANCE_MS = 30_000;
 export const VALIDITY_MS = 1000 * 60 * 60 * 24 * 365;
+export const CA_VALIDITY_MS = 1000 * 60 * 60 * 24 * 365 * 5; // 5 years — root CA lifetime
 
 // Re-export config loading functions
 export {

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -5,7 +5,7 @@ import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, KeyPair } from "@/types";
 
 import { CertificateBuilder } from "./pem";
-import { loadJwks } from "./utils";
+import { CA_VALIDITY_MS, loadJwks } from "./utils";
 
 /**
  * Loads (or lazily generates and caches on disk) an X.509 certificate for the
@@ -52,6 +52,7 @@ export async function loadWalletProviderCertificateChain(
     .withKeyPair(taJwks)
     .selfSigned()
     .withCaCapability(0)
+    .withValidity(CA_VALIDITY_MS)
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
 
   const certWpResult = await new CertificateBuilder()

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,14 +1,15 @@
 import * as x509 from "@peculiar/x509";
+import { writeFileSync } from "node:fs";
 
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, KeyPair } from "@/types";
 
 import { CertificateBuilder } from "./pem";
-import { CA_VALIDITY_MS, loadJwks } from "./utils";
+import { buildJwksPath, CA_VALIDITY_MS, loadJwks } from "./utils";
 
 /**
- * Loads (or lazily generates and caches on disk) an X.509 certificate for the
+ * Loads (or lazily generates and caches on disk) an X.509 certificate chain for the
  * wallet provider key pair, suitable for use in
  * WalletAttestationOptionsV1_3.signer.x5c.
  *
@@ -16,6 +17,7 @@ import { CA_VALIDITY_MS, loadJwks } from "./utils";
  * loadTAJwksWithSelfSignedX5c.
  *
  * @param wallet - The wallet configuration section from Config
+ * @param unitKeyPair - The unit key pair loaded from backup_storage_path
  * @param providerKeyPair - The provider key pair loaded from backup_storage_path
  * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
  */
@@ -26,23 +28,67 @@ export async function loadWalletProviderCertificateChain(
   trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
   const wpHostname = new URL(LOCAL_WP_HOST).hostname;
-  const wpSanExtension = new x509.SubjectAlternativeNameExtension(
-    [
-      { type: "url", value: LOCAL_WP_HOST },
-      { type: "dns", value: wpHostname },
-    ],
-    false,
-  );
+  const wpSanExtension = buildWpSanExtension(wpHostname);
 
   const certWpSelfIssuedResult = await new CertificateBuilder()
     .withSubject(`CN=${wpHostname}`)
     .withKeyPair(unitKeyPair)
     .selfIssued(providerKeyPair)
     .withExtensions([wpSanExtension])
-    .loadOrCreate(
-      wallet.backup_storage_path,
-      "wallet_unit_self_issued_cert",
-    );
+    .loadOrCreate(wallet.backup_storage_path, "wallet_unit_self_issued_cert");
+
+  const wpCertDer = await loadWPCertificateChain(
+    wallet,
+    providerKeyPair,
+    trust,
+  );
+
+  return [certWpSelfIssuedResult.certDerBase64, wpCertDer];
+}
+
+/**
+ * Loads (or creates) the Wallet Unit JWKS and its self-issued certificate.
+ * Embeds the certificate DER in publicKey.x5c and saves the updated JWKS to disk.
+ */
+export async function loadWalletUnitJwksWithCert(
+  wallet: Config["wallet"],
+  providerKeyPair: KeyPair,
+): Promise<KeyPair> {
+  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
+  const wpSanExtension = buildWpSanExtension(wpHostname);
+
+  const unitKeyPair = await loadJwks(
+    wallet.backup_storage_path,
+    buildJwksPath("wallet_unit"),
+  );
+
+  const certResult = await new CertificateBuilder()
+    .withSubject(`CN=${wpHostname}`)
+    .withKeyPair(unitKeyPair)
+    .selfIssued(providerKeyPair)
+    .withExtensions([wpSanExtension])
+    .loadOrCreate(wallet.backup_storage_path, "wallet_unit_self_issued_cert");
+
+  unitKeyPair.publicKey.x5c = [certResult.certDerBase64];
+  writeFileSync(
+    `${wallet.backup_storage_path}/${buildJwksPath("wallet_unit")}`,
+    JSON.stringify(unitKeyPair),
+  );
+
+  return unitKeyPair;
+}
+
+/**
+ * Loads (or lazily generates and caches on disk) the TA CA cert and the WP cert
+ * signed by the TA. Returns the WP cert DER base64.
+ */
+export async function loadWPCertificateChain(
+  wallet: Config["wallet"],
+  providerKeyPair: KeyPair,
+  trust: Config["trust"],
+): Promise<string> {
+  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
+  const wpSanExtension = buildWpSanExtension(wpHostname);
 
   const taJwks = await loadJwks(
     trust.federation_trust_anchors_jwks_path,
@@ -61,12 +107,19 @@ export async function loadWalletProviderCertificateChain(
     .withKeyPair(providerKeyPair)
     .signedBy(certTAResult.certificate, taJwks)
     .withExtensions([wpSanExtension])
-    .loadOrCreate(
-      wallet.backup_storage_path,
-      "wallet_provider_cert",
-    );
-  return [
-    certWpSelfIssuedResult.certDerBase64,
-    certWpResult.certDerBase64,
-  ];
+    .loadOrCreate(wallet.backup_storage_path, "wallet_provider_cert");
+
+  return certWpResult.certDerBase64;
+}
+
+function buildWpSanExtension(
+  wpHostname: string,
+): x509.SubjectAlternativeNameExtension {
+  return new x509.SubjectAlternativeNameExtension(
+    [
+      { type: "url", value: LOCAL_WP_HOST },
+      { type: "dns", value: wpHostname },
+    ],
+    false,
+  );
 }

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -39,6 +39,7 @@ export async function loadWalletProviderCertificateChain(
     .withSubject(`CN=${LOCAL_TA_HOST}`)
     .withKeyPair(taJwks)
     .selfSigned()
+    .withCaCapability(0)
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
 
   const certWpResult = await new CertificateBuilder()
@@ -47,7 +48,7 @@ export async function loadWalletProviderCertificateChain(
     .signedBy(certTAResult.certificate, taJwks)
     .loadOrCreate(
       wallet.backup_storage_path,
-      "wallet_provider_self_signed_cert",
+      "wallet_provider_cert",
     );
   return [
     certWpSelfSignedResult.certDerBase64,

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -27,11 +27,10 @@ export async function loadWalletProviderCertificateChain(
   providerKeyPair: KeyPair,
   trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
-  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
-  const wpSanExtension = buildWpSanExtension(wpHostname);
+  const wpSanExtension = buildWpSanExtension(LOCAL_WP_HOST);
 
   const certWpSelfIssuedResult = await new CertificateBuilder()
-    .withSubject(`CN=${wpHostname}`)
+    .withSubject(`CN=${LOCAL_WP_HOST}`)
     .withKeyPair(unitKeyPair)
     .selfIssued(providerKeyPair)
     .withExtensions([wpSanExtension])
@@ -54,8 +53,7 @@ export async function loadWalletUnitJwksWithCert(
   wallet: Config["wallet"],
   providerKeyPair: KeyPair,
 ): Promise<KeyPair> {
-  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
-  const wpSanExtension = buildWpSanExtension(wpHostname);
+  const wpSanExtension = buildWpSanExtension(LOCAL_WP_HOST);
 
   const unitKeyPair = await loadJwks(
     wallet.backup_storage_path,
@@ -63,7 +61,7 @@ export async function loadWalletUnitJwksWithCert(
   );
 
   const certResult = await new CertificateBuilder()
-    .withSubject(`CN=${wpHostname}`)
+    .withSubject(`CN=${LOCAL_WP_HOST}`)
     .withKeyPair(unitKeyPair)
     .selfIssued(providerKeyPair)
     .withExtensions([wpSanExtension])
@@ -87,8 +85,7 @@ export async function loadWPCertificateChain(
   providerKeyPair: KeyPair,
   trust: Config["trust"],
 ): Promise<string> {
-  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
-  const wpSanExtension = buildWpSanExtension(wpHostname);
+  const wpSanExtension = buildWpSanExtension(LOCAL_WP_HOST);
 
   const taJwks = await loadJwks(
     trust.federation_trust_anchors_jwks_path,
@@ -103,7 +100,7 @@ export async function loadWPCertificateChain(
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
 
   const certWpResult = await new CertificateBuilder()
-    .withSubject(`CN=${wpHostname}`)
+    .withSubject(`CN=${LOCAL_WP_HOST}`)
     .withKeyPair(providerKeyPair)
     .signedBy(certTAResult.certificate, taJwks)
     .withExtensions([wpSanExtension])

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,3 +1,5 @@
+import * as x509 from "@peculiar/x509";
+
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, KeyPair } from "@/types";
@@ -22,10 +24,20 @@ export async function loadWalletProviderCertificateChain(
   providerKeyPair: KeyPair,
   trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
+  const wpHostname = new URL(LOCAL_WP_HOST).hostname;
+  const wpSanExtension = new x509.SubjectAlternativeNameExtension(
+    [
+      { type: "url", value: LOCAL_WP_HOST },
+      { type: "dns", value: wpHostname },
+    ],
+    false,
+  );
+
   const certWpSelfSignedResult = await new CertificateBuilder()
-    .withSubject(`CN=${LOCAL_WP_HOST}`)
+    .withSubject(`CN=${wpHostname}`)
     .withKeyPair(providerKeyPair)
     .selfSigned()
+    .withExtensions([wpSanExtension])
     .loadOrCreate(
       wallet.backup_storage_path,
       "wallet_provider_self_signed_cert",
@@ -43,9 +55,10 @@ export async function loadWalletProviderCertificateChain(
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
 
   const certWpResult = await new CertificateBuilder()
-    .withSubject(`CN=${LOCAL_WP_HOST}`)
+    .withSubject(`CN=${wpHostname}`)
     .withKeyPair(providerKeyPair)
     .signedBy(certTAResult.certificate, taJwks)
+    .withExtensions([wpSanExtension])
     .loadOrCreate(
       wallet.backup_storage_path,
       "wallet_provider_cert",

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,7 +1,9 @@
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
-import { loadCertificate } from "./pem";
+import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, KeyPair } from "@/types";
 
+import { CertificateBuilder } from "./pem";
+import { loadJwks } from "./utils";
 
 /**
  * Loads (or lazily generates and caches on disk) an X.509 certificate for the
@@ -15,16 +17,41 @@ import { Config, KeyPair } from "@/types";
  * @param providerKeyPair - The provider key pair loaded from backup_storage_path
  * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
  */
-export async function loadWalletProviderCertificate(
+export async function loadWalletProviderCertificateChain(
   wallet: Config["wallet"],
   providerKeyPair: KeyPair,
+  trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
-  const providerDomain = LOCAL_WP_HOST;
-  const cert = await loadCertificate(
-    wallet.backup_storage_path,
-    "wallet_provider_cert",
-    providerKeyPair,
-    `CN=${providerDomain}`,
+  const certWpSelfSignedResult = await new CertificateBuilder()
+    .withSubject(`CN=${LOCAL_WP_HOST}`)
+    .withKeyPair(providerKeyPair)
+    .selfSigned()
+    .loadOrCreate(
+      wallet.backup_storage_path,
+      "wallet_provider_self_signed_cert",
+    );
+
+  const taJwks = await loadJwks(
+    trust.federation_trust_anchors_jwks_path,
+    "trust_anchor",
   );
-  return [cert];
+  const certTAResult = await new CertificateBuilder()
+    .withSubject(`CN=${LOCAL_TA_HOST}`)
+    .withKeyPair(taJwks)
+    .selfSigned()
+    .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
+
+  const certWpResult = await new CertificateBuilder()
+    .withSubject(`CN=${LOCAL_WP_HOST}`)
+    .withKeyPair(providerKeyPair)
+    .signedBy(certTAResult.certificate, taJwks)
+    .loadOrCreate(
+      wallet.backup_storage_path,
+      "wallet_provider_self_signed_cert",
+    );
+  return [
+    certWpSelfSignedResult.certDerBase64,
+    certWpResult.certDerBase64,
+    certTAResult.certDerBase64,
+  ];
 }

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -21,6 +21,7 @@ import { CA_VALIDITY_MS, loadJwks } from "./utils";
  */
 export async function loadWalletProviderCertificateChain(
   wallet: Config["wallet"],
+  unitKeyPair: KeyPair,
   providerKeyPair: KeyPair,
   trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
@@ -33,14 +34,14 @@ export async function loadWalletProviderCertificateChain(
     false,
   );
 
-  const certWpSelfSignedResult = await new CertificateBuilder()
+  const certWpSelfIssuedResult = await new CertificateBuilder()
     .withSubject(`CN=${wpHostname}`)
-    .withKeyPair(providerKeyPair)
-    .selfSigned()
+    .withKeyPair(unitKeyPair)
+    .selfIssued(providerKeyPair)
     .withExtensions([wpSanExtension])
     .loadOrCreate(
       wallet.backup_storage_path,
-      "wallet_provider_self_signed_cert",
+      "wallet_unit_self_issued_cert",
     );
 
   const taJwks = await loadJwks(
@@ -50,7 +51,7 @@ export async function loadWalletProviderCertificateChain(
   const certTAResult = await new CertificateBuilder()
     .withSubject(`CN=${LOCAL_TA_HOST}`)
     .withKeyPair(taJwks)
-    .selfSigned()
+    .selfIssued()
     .withCaCapability(0)
     .withValidity(CA_VALIDITY_MS)
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
@@ -65,8 +66,7 @@ export async function loadWalletProviderCertificateChain(
       "wallet_provider_cert",
     );
   return [
-    certWpSelfSignedResult.certDerBase64,
+    certWpSelfIssuedResult.certDerBase64,
     certWpResult.certDerBase64,
-    certTAResult.certDerBase64,
   ];
 }

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -5,7 +5,7 @@ import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { LOCAL_TA_HOST } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, KeyPair } from "@/types";
 
-import { CertificateBuilder } from "./pem";
+import { CertificateBuilder, CertificateResult } from "./pem";
 import { buildJwksPath, CA_VALIDITY_MS, loadJwks } from "./utils";
 
 /**
@@ -23,26 +23,21 @@ import { buildJwksPath, CA_VALIDITY_MS, loadJwks } from "./utils";
  */
 export async function loadWalletProviderCertificateChain(
   wallet: Config["wallet"],
-  unitKeyPair: KeyPair,
   providerKeyPair: KeyPair,
   trust: Config["trust"],
 ): Promise<[string, ...string[]]> {
   const wpSanExtension = buildWpSanExtension(LOCAL_WP_HOST);
 
+  const wpCertResult = await loadWPCertificateChain(wallet, trust);
+
   const certWpSelfIssuedResult = await new CertificateBuilder()
     .withSubject(`CN=${LOCAL_WP_HOST}`)
-    .withKeyPair(unitKeyPair)
-    .selfIssued(providerKeyPair)
+    .withKeyPair(providerKeyPair)
+    .selfIssued(wpCertResult.keyPair)
     .withExtensions([wpSanExtension])
     .loadOrCreate(wallet.backup_storage_path, "wallet_unit_self_issued_cert");
 
-  const wpCertDer = await loadWPCertificateChain(
-    wallet,
-    providerKeyPair,
-    trust,
-  );
-
-  return [certWpSelfIssuedResult.certDerBase64, wpCertDer];
+  return [certWpSelfIssuedResult.certDerBase64, wpCertResult.certDerBase64];
 }
 
 /**
@@ -77,14 +72,12 @@ export async function loadWalletUnitJwksWithCert(
 }
 
 /**
- * Loads (or lazily generates and caches on disk) the TA CA cert and the WP cert
- * signed by the TA. Returns the WP cert DER base64.
+ * Loads the Wallet Provider cert signed by the TA which contains keys to sign self-issued certs that contains wallet provider keys.
  */
 export async function loadWPCertificateChain(
   wallet: Config["wallet"],
-  providerKeyPair: KeyPair,
   trust: Config["trust"],
-): Promise<string> {
+): Promise<CertificateResult> {
   const wpSanExtension = buildWpSanExtension(LOCAL_WP_HOST);
 
   const taJwks = await loadJwks(
@@ -99,14 +92,19 @@ export async function loadWPCertificateChain(
     .withValidity(CA_VALIDITY_MS)
     .loadOrCreate(trust.ca_cert_path, "trust_anchor_cert");
 
+  const wpCertJwks = await loadJwks(
+    wallet.backup_storage_path,
+    buildJwksPath("wallet_provider_cert"),
+  );
+
   const certWpResult = await new CertificateBuilder()
     .withSubject(`CN=${LOCAL_WP_HOST}`)
-    .withKeyPair(providerKeyPair)
+    .withKeyPair(wpCertJwks)
     .signedBy(certTAResult.certificate, taJwks)
     .withExtensions([wpSanExtension])
     .loadOrCreate(wallet.backup_storage_path, "wallet_provider_cert");
 
-  return certWpResult.certDerBase64;
+  return certWpResult;
 }
 
 function buildWpSanExtension(

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -114,7 +114,7 @@ function buildWpSanExtension(
 ): x509.SubjectAlternativeNameExtension {
   return new x509.SubjectAlternativeNameExtension(
     [
-      { type: "url", value: LOCAL_WP_HOST },
+      { type: "url", value: `https://${wpHostname}` },
       { type: "dns", value: wpHostname },
     ],
     false,

--- a/src/servers/ci-server.ts
+++ b/src/servers/ci-server.ts
@@ -59,7 +59,7 @@ export const createServer = (config: Config): express.Express => {
     try {
       const jwt = await createStatusListToken({
         certFilename: "issuer_cert",
-        certSubject: "CN=test_issuer",
+        certSubject: "CN=${LOCAL_CI_HOST}",
         iss: ciBaseUrl,
         jwksFilename: buildJwksPath("issuer_pid_mocked"),
         jwksPath: config.wallet.backup_storage_path,

--- a/src/servers/ci-server.ts
+++ b/src/servers/ci-server.ts
@@ -59,7 +59,7 @@ export const createServer = (config: Config): express.Express => {
     try {
       const jwt = await createStatusListToken({
         certFilename: "issuer_cert",
-        certSubject: "CN=${LOCAL_CI_HOST}",
+        certSubject: `CN=${LOCAL_CI_HOST}`,
         iss: ciBaseUrl,
         jwksFilename: buildJwksPath("issuer_pid_mocked"),
         jwksPath: config.wallet.backup_storage_path,

--- a/src/servers/ta-server.ts
+++ b/src/servers/ta-server.ts
@@ -54,7 +54,7 @@ export const createServer = (config: Config): express.Express => {
           sub,
           trustAnchor: config.trust,
           trustAnchorBaseUrl,
-          walletBackupStoragePath: config.wallet.backup_storage_path,
+          wallet: config.wallet,
         });
       } else if (sub === ciBaseUrl) {
         subordinateStatement = await createSubordinateCredentialIssuerMetadata({

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -113,10 +113,11 @@ export class CredentialRequestDefaultStep extends StepFlow {
     walletAttestation: CredentialRequestStepOptions["walletAttestation"],
     credentialKeyPair: KeyPair,
   ): Promise<string> {
-    const { providerKey } = walletAttestation;
+    const { providerKey, unitKey } = walletAttestation;
 
     const x5c = await loadWalletProviderCertificateChain(
       this.config.wallet,
+      unitKey,
       providerKey,
       this.config.trust,
     );

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -24,7 +24,7 @@ import {
   createAndSaveKeys,
   createKeys,
   fetchWithConfig,
-  loadWalletProviderCertificate,
+  loadWalletProviderCertificateChain,
   partialCallbacks,
   signJwtCallback,
 } from "@/logic";
@@ -115,9 +115,10 @@ export class CredentialRequestDefaultStep extends StepFlow {
   ): Promise<string> {
     const { providerKey } = walletAttestation;
 
-    const x5c = await loadWalletProviderCertificate(
+    const x5c = await loadWalletProviderCertificateChain(
       this.config.wallet,
       providerKey,
+      this.config.trust,
     );
 
     const provider = new WalletProvider(this.ioWalletSdkConfig);


### PR DESCRIPTION
#### Motivation and Context

This PR aims to fix how is builded x5c chain of wallet attestation, previous only wallet provider certificare was included. In addition, it was done a refactor of certificate handling enhances usability and maintainability. The changes streamline the loading of wallet provider certificates and improve the overall structure of the code.

#### How Has This Been Tested?

Changes were tested by verifying the functionality of the new `loadWalletProviderCertificateChain` method and ensuring that the `CertificateBuilder` operates correctly. Testing included checking the generation and loading of certificates in various scenarios to confirm that existing functionality remains intact.

