### PR TITLE
fix: presentation cli command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,15 +10,33 @@ import { execFileSync } from "child_process";
 import { Command } from "commander";
 import { resolve } from "path";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { version } = require("../package.json") as { version: string };
+import type { CliOptions } from "@/logic";
+
+import { version } from "../package.json";
+
+function runTestCommand(
+  script: "test:issuance" | "test:presentation",
+  options: CliOptions,
+) {
+  const env = setEnvFromOptions(options);
+  const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
+
+  try {
+    execFileSync("pnpm", [script, ...tests], {
+      env,
+      stdio: "inherit",
+    });
+  } catch {
+    process.exit(1);
+  }
+}
 
 /**
  * Sets environment variables from CLI options
  * @param options Commander options object
  * @returns Updated environment object
  */
-function setEnvFromOptions(options: any): NodeJS.ProcessEnv {
+function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   const env = { ...process.env };
 
   if (options.fileIni) {
@@ -179,17 +197,7 @@ const testIssuance = program
 addCommonOptions(testIssuance);
 
 testIssuance.action((options) => {
-  const env = setEnvFromOptions(options);
-  const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
-
-  try {
-    execFileSync("pnpm", ["test:issuance", ...tests], {
-      env,
-      stdio: "inherit",
-    });
-  } catch {
-    process.exit(1);
-  }
+  runTestCommand("test:issuance", options);
 });
 
 // Test Presentation Flow
@@ -200,17 +208,7 @@ const testPresentation = program
 addCommonOptions(testPresentation);
 
 testPresentation.action((options) => {
-  const env = setEnvFromOptions(options);
-  const tests = env.TESTS?.split(/\s*,\s*/g).filter((i) => i.length > 0) ?? [];
-
-  try {
-    execFileSync("pnpm", ["test:issuance", ...tests], {
-      env,
-      stdio: "inherit",
-    });
-  } catch {
-    process.exit(1);
-  }
+  runTestCommand("test:presentation", options);
 });
 
 // Parse command-line arguments

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -28,6 +28,7 @@ export interface CliOptions {
   presentationTestsDir?: string;
   saveCredential?: boolean;
   stepsMapping?: string;
+  tests?: string;
   timeout?: number;
   trustAnchorCertDir?: string;
   unsafeTls?: boolean;


### PR DESCRIPTION
This pull request fix the wrong configuration regression for the CLI presentation command and refactors the CLI test command logic to reduce code duplication and improve maintainability. The main change is the introduction of a reusable `runTestCommand` function for running test commands, which simplifies the action handlers for both issuance and presentation test flows. Additionally, the `CliOptions` type is updated for better type safety.

Resolve WLEO-1152

Refactoring and code simplification:

* Introduced a new `runTestCommand` function in `src/cli.ts` to encapsulate the logic for running test commands, replacing duplicated code in the test command action handlers.
* Updated the `test:issuance` and `test:presentation` command action handlers in `src/cli.ts` to use the new `runTestCommand` function, reducing repeated logic. [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL182-R200) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL203-R211)

Type safety improvements:

* Updated the `CliOptions` interface in `src/logic/config-loader.ts` to include a new optional `tests` property, and used this type for option typing in related functions. [[1]](diffhunk://#diff-76bf197369664af044a578aa64cbf19b406b5e64bf5a2191e3ec999855f18fbbR31) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL13-R39)