### PR TITLE
Fix signCallback to use crypto.subtle when sign federation metadata

### DIFF
--- a/src/logic/jwt.ts
+++ b/src/logic/jwt.ts
@@ -9,7 +9,6 @@ import type {
 import { SignCallback } from "@pagopa/io-wallet-oid-federation";
 import {
   CompactEncrypt,
-  CompactSign,
   importJWK,
   type JWK,
   jwtVerify,
@@ -48,33 +47,29 @@ export function signJwtCallback(privateJwks: JWK[]): SignJwtCallback {
 /**
  * Signs the given payload using the provided JWK and returns the raw signature bytes.
  *
- * @param toBeSigned - The payload to sign (typically the header and payload of a JWT)
+ * @param toBeSigned - The signing input bytes ("header_b64url.payload_b64url")
  * @param jwk - The JSON Web Key to use for signing
- * @returns A Buffer containing the raw signature bytes
+ * @returns A Uint8Array containing the raw signature bytes
  */
 export const signCallback: SignCallback = async ({ jwk, toBeSigned }) => {
   const alg = jwk.alg ?? "ES256";
   const key = await importJWK(jwk as unknown as JWK, alg);
 
-  // sign with JWS compact format.
-  const jws = await new CompactSign(toBeSigned)
-    .setProtectedHeader({ alg: alg })
-    .sign(key);
-
-  // JWS compact format is "header.payload.signature"
-  const parts = jws.split(".");
-  if (parts.length !== 3) {
-    throw new Error("JWS compact format is not valid");
-  }
-  const signatureBase64Url = parts[2];
-  if (!signatureBase64Url) {
-    throw new Error("Invalid JWS format: signature part is empty");
-  }
-  const signatureBytes = new Uint8Array(
-    Buffer.from(signatureBase64Url, "base64url"),
+  // crypto.subtle.sign requires the hash algorithm to be specified explicitly as a
+  // Web Crypto API name ("SHA-256", "SHA-384", "SHA-512"), whereas JWA algorithm names
+  // (e.g. "ES256") encode both the curve and the hash in a single string.
+  // importJWK already selects the correct curve from the JWK, but crypto.subtle
+  // does not derive the hash automatically — it must be passed separately.
+  // ES256 → SHA-256, ES384 → SHA-384, ES512 → SHA-512 (per RFC 7518 §3.4).
+  const hashAlgorithm = alg === "ES384" ? "SHA-384" : alg === "ES512" ? "SHA-512" : "SHA-256";
+  const signatureBuffer = await crypto.subtle.sign(
+    { name: "ECDSA", hash: hashAlgorithm },
+    key as CryptoKey,
+    // Buffer.from copies bytes into a plain ArrayBuffer, satisfying BufferSource type
+    Buffer.from(toBeSigned),
   );
 
-  return signatureBytes;
+  return new Uint8Array(signatureBuffer);
 };
 
 /**

--- a/src/logic/jwt.ts
+++ b/src/logic/jwt.ts
@@ -7,13 +7,7 @@ import type {
 } from "@pagopa/io-wallet-oauth2";
 
 import { SignCallback } from "@pagopa/io-wallet-oid-federation";
-import {
-  CompactEncrypt,
-  importJWK,
-  type JWK,
-  jwtVerify,
-  SignJWT,
-} from "jose";
+import { CompactEncrypt, importJWK, type JWK, jwtVerify, SignJWT } from "jose";
 
 import { jwkFromSigner } from "./jwk";
 
@@ -61,9 +55,10 @@ export const signCallback: SignCallback = async ({ jwk, toBeSigned }) => {
   // importJWK already selects the correct curve from the JWK, but crypto.subtle
   // does not derive the hash automatically — it must be passed separately.
   // ES256 → SHA-256, ES384 → SHA-384, ES512 → SHA-512 (per RFC 7518 §3.4).
-  const hashAlgorithm = alg === "ES384" ? "SHA-384" : alg === "ES512" ? "SHA-512" : "SHA-256";
+  const hashAlgorithm =
+    alg === "ES384" ? "SHA-384" : alg === "ES512" ? "SHA-512" : "SHA-256";
   const signatureBuffer = await crypto.subtle.sign(
-    { name: "ECDSA", hash: hashAlgorithm },
+    { hash: hashAlgorithm, name: "ECDSA" },
     key as CryptoKey,
     // Buffer.from copies bytes into a plain ArrayBuffer, satisfying BufferSource type
     Buffer.from(toBeSigned),

--- a/src/logic/jwt.ts
+++ b/src/logic/jwt.ts
@@ -60,7 +60,6 @@ export const signCallback: SignCallback = async ({ jwk, toBeSigned }) => {
   const signatureBuffer = await crypto.subtle.sign(
     { hash: hashAlgorithm, name: "ECDSA" },
     key as CryptoKey,
-    // Buffer.from copies bytes into a plain ArrayBuffer, satisfying BufferSource type
     Buffer.from(toBeSigned),
   );
 

--- a/tests/unit/jwt.unit.spec.ts
+++ b/tests/unit/jwt.unit.spec.ts
@@ -1,0 +1,101 @@
+import type { JsonWebKey } from "@pagopa/io-wallet-oid-federation";
+
+import { describe, expect, it } from "vitest";
+
+import { signCallback } from "@/logic/jwt";
+
+/**
+ * Unit tests for signCallback in src/logic/jwt.ts.
+ *
+ * These tests verify:
+ *   - the return value is a Uint8Array
+ *   - the raw bytes form a valid ECDSA signature verifiable with the
+ *     matching public key
+ *   - the hash algorithm is correctly derived from the JWA alg name
+ *     (ES256→SHA-256, ES384→SHA-384, ES512→SHA-512)
+ *   - when alg is absent the function defaults to ES256/SHA-256
+ */
+
+/**
+ * Generate an extractable ECDSA key pair using Web Crypto and export both
+ * halves as plain JWK objects. Using crypto.subtle directly (rather than
+ * jose's generateKeyPair) so the keys are extractable.
+ */
+async function generateExtractableEcKeyPair(namedCurve: string): Promise<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- crypto.subtle.exportKey returns DOM JsonWebKey; any is needed to spread extra fields
+  privateJwk: any;
+  publicKey: CryptoKey;
+}> {
+  const { privateKey, publicKey } = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve },
+    true /* extractable */,
+    ["sign", "verify"],
+  );
+  const privateJwk = await crypto.subtle.exportKey("jwk", privateKey);
+  return { privateJwk, publicKey };
+}
+
+describe("signCallback", () => {
+  it.each([
+    { alg: "ES256", hashAlgorithm: "SHA-256" as const, namedCurve: "P-256" },
+    { alg: "ES384", hashAlgorithm: "SHA-384" as const, namedCurve: "P-384" },
+    { alg: "ES512", hashAlgorithm: "SHA-512" as const, namedCurve: "P-521" },
+  ])(
+    "$alg: returns a Uint8Array that verifies against the public key",
+    async ({ alg, hashAlgorithm, namedCurve }) => {
+      const { privateJwk, publicKey } =
+        await generateExtractableEcKeyPair(namedCurve);
+
+      const jwk = {
+        ...privateJwk,
+        alg,
+        kid: "test-key",
+      } as unknown as JsonWebKey;
+
+      const toBeSigned = new TextEncoder().encode("header.payload");
+
+      const signature = await signCallback({ jwk, toBeSigned });
+
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBeGreaterThan(0);
+
+      const isValid = await crypto.subtle.verify(
+        { hash: hashAlgorithm, name: "ECDSA" },
+        publicKey,
+        Buffer.from(signature),
+        toBeSigned,
+      );
+
+      expect(
+        isValid,
+        `signature should be valid for ${alg} with ${hashAlgorithm}`,
+      ).toBe(true);
+    },
+  );
+
+  it("defaults to ES256/SHA-256 when alg is absent from the JWK", async () => {
+    const { privateJwk, publicKey } =
+      await generateExtractableEcKeyPair("P-256");
+
+    // Intentionally omit alg to exercise the ?? "ES256" branch
+    const jwk = { ...privateJwk, kid: "test-key" } as unknown as JsonWebKey;
+
+    const toBeSigned = new TextEncoder().encode("header.payload");
+
+    const signature = await signCallback({ jwk, toBeSigned });
+
+    expect(signature).toBeInstanceOf(Uint8Array);
+
+    const isValid = await crypto.subtle.verify(
+      { hash: "SHA-256", name: "ECDSA" },
+      publicKey,
+      Buffer.from(signature),
+      toBeSigned,
+    );
+
+    expect(
+      isValid,
+      "signature should verify with SHA-256 when alg is absent",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
#### Motivation and Context

Refactoring of the `signCallback` function utilizing the `crypto.subtle` API for signing operations. This change fix the sign over federation metadata exposed by local federation server.

#### How Has This Been Tested?

Unit tests have been added to verify the functionality of the `signCallback` method. Tests confirm that the return value is a `Uint8Array`, validate the ECDSA signature against the public key, and ensure correct derivation of the hash algorithm from the JWK. The default behavior when the algorithm is absent has also been tested.

