### PR TITLE
Sign WP certificate with TA key intermediate CA

### DIFF
--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -120,7 +120,11 @@ const buildAttestationOptions = async (
       return attestationOptions;
     }
     case ItWalletSpecsVersion.V1_3: {
-      const x5c = await loadWalletProviderCertificate(wallet, trust, providerKeyPair);
+      const x5c = await loadWalletProviderCertificate(
+        wallet,
+        trust,
+        providerKeyPair,
+      );
       const attestationOptions: WalletAttestationOptions = {
         ...commonOptions,
         signer: { ...signerBase, method: "x5c", trustChain, x5c },

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -88,6 +88,7 @@ export const buildWpEntityConfiguration = async (
 
 const buildAttestationOptions = async (
   wallet: Config["wallet"],
+  trust: Config["trust"],
   providerKeyPair: KeyPair,
   unitPublicKey: KeyPair["publicKey"],
   trustChain: [string, string],
@@ -119,7 +120,7 @@ const buildAttestationOptions = async (
       return attestationOptions;
     }
     case ItWalletSpecsVersion.V1_3: {
-      const x5c = await loadWalletProviderCertificate(wallet, providerKeyPair);
+      const x5c = await loadWalletProviderCertificate(wallet, trust, providerKeyPair);
       const attestationOptions: WalletAttestationOptions = {
         ...commonOptions,
         signer: { ...signerBase, method: "x5c", trustChain, x5c },
@@ -161,6 +162,7 @@ const createAttestation = async (
 
   const attestationOptions = await buildAttestationOptions(
     wallet,
+    trust,
     providerKeyPair,
     unitKeyPair.publicKey,
     [wpEntityConfiguration, taEntityConfiguration],

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -213,21 +213,15 @@ export async function createSignedCertificate(
   const cert = await x509.X509CertificateGenerator.create({
     extensions,
     issuer: issuerSubject,
-    subject: subjectName,
     notAfter,
     notBefore,
     publicKey,
     signingAlgorithm,
     signingKey,
+    subject: subjectName,
   });
 
   return cert;
-}
-
-export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
-  const certificate =
-    typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
-  return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
 }
 
 /**
@@ -235,6 +229,12 @@ export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
  */
 export function hasAnyCertificateExpired(x5cChain: string[]): boolean {
   return x5cChain.some((cert) => hasX509CertificateExpired(cert));
+}
+
+export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
+  const certificate =
+    typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
+  return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -144,10 +144,97 @@ export async function createCertificate(
   return cert;
 }
 
+/**
+ * Creates an X.509 certificate signed by an issuer (CA) key pair.
+ *
+ * Unlike {@link createCertificate}, which produces a self-signed certificate,
+ * this function uses `X509CertificateGenerator.create()` so the resulting
+ * certificate is signed by a different issuer key.
+ *
+ * @param issuerKeyPair - The issuer's key pair used to sign the certificate.
+ * @param issuerSubject - The issuer's distinguished name (e.g. "CN=TrustAnchor").
+ * @param subjectKeyPair - The subject's key pair whose public key is certified.
+ * @param subjectName - The subject's distinguished name.
+ * @param isCA - Whether this certificate is a CA certificate (BasicConstraints).
+ * @returns The signed X.509 certificate.
+ */
+export async function createSignedCertificate(
+  issuerKeyPair: KeyPair,
+  issuerSubject: string,
+  subjectKeyPair: KeyPair,
+  subjectName: string,
+  isCA: boolean,
+): Promise<x509.X509Certificate> {
+  const signingAlgorithm = {
+    hash: "SHA-256",
+    name: "ECDSA",
+    namedCurve: "P-256",
+  };
+
+  const signingKey = await crypto.subtle.importKey(
+    "jwk",
+    issuerKeyPair.privateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"],
+  );
+
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    subjectKeyPair.publicKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"],
+  );
+
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
+
+  const extensions: x509.Extension[] = [
+    new x509.BasicConstraintsExtension(isCA, undefined, true),
+    new x509.KeyUsagesExtension(
+      isCA
+        ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.digitalSignature
+        : x509.KeyUsageFlags.digitalSignature,
+      true,
+    ),
+    await x509.SubjectKeyIdentifierExtension.create(publicKey),
+  ];
+
+  if (!isCA) {
+    extensions.push(
+      new x509.ExtendedKeyUsageExtension(
+        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
+        false,
+      ),
+    );
+  }
+
+  const cert = await x509.X509CertificateGenerator.create({
+    extensions,
+    issuer: issuerSubject,
+    subject: subjectName,
+    notAfter,
+    notBefore,
+    publicKey,
+    signingAlgorithm,
+    signingKey,
+  });
+
+  return cert;
+}
+
 export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
   return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
+}
+
+/**
+ * Returns `true` if any certificate in the given base64-DER array is expired.
+ */
+export function hasAnyCertificateExpired(x5cChain: string[]): boolean {
+  return x5cChain.some((cert) => hasX509CertificateExpired(cert));
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -1,4 +1,5 @@
 import * as x509 from "@peculiar/x509";
+import { randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -13,6 +14,12 @@ import { KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
 import { CLOCK_SKEW_TOLERANCE_MS, ensureDir, VALIDITY_MS } from "./utils";
+
+const SIGNING_ALGORITHM = {
+  hash: "SHA-256",
+  name: "ECDSA",
+  namedCurve: "P-256",
+} as const satisfies EcdsaParams & EcKeyImportParams;
 
 /**
  * Creates a self-signed X.509 certificate and saves it to a file in PEM format.
@@ -70,7 +77,7 @@ export async function createAndSaveCertificateWithKey(
   const privateKey = await crypto.subtle.importKey(
     "jwk",
     keyPair.privateKey,
-    { name: "ECDSA", namedCurve: "P-256" },
+    SIGNING_ALGORITHM,
     true,
     ["sign"],
   );
@@ -96,16 +103,11 @@ export async function createCertificate(
   extraExtensions: x509.Extension[] = [],
 ): Promise<x509.X509Certificate> {
   // Import JWK -> CryptoKey
-  const signingAlgorithm = {
-    hash: "SHA-256",
-    name: "ECDSA",
-    namedCurve: "P-256",
-  };
 
   const privateKey = await crypto.subtle.importKey(
     "jwk",
     keyPair.privateKey,
-    { name: "ECDSA", namedCurve: "P-256" },
+    SIGNING_ALGORITHM,
     true,
     ["sign"],
   );
@@ -113,7 +115,7 @@ export async function createCertificate(
   const publicKey = await crypto.subtle.importKey(
     "jwk",
     keyPair.publicKey,
-    { name: "ECDSA", namedCurve: "P-256" },
+    SIGNING_ALGORITHM,
     true,
     ["verify"],
   );
@@ -138,7 +140,7 @@ export async function createCertificate(
     name: subject,
     notAfter,
     notBefore,
-    signingAlgorithm,
+    signingAlgorithm: SIGNING_ALGORITHM,
   });
 
   return cert;
@@ -165,16 +167,10 @@ export async function createSignedCertificate(
   subjectName: string,
   isCA: boolean,
 ): Promise<x509.X509Certificate> {
-  const signingAlgorithm = {
-    hash: "SHA-256",
-    name: "ECDSA",
-    namedCurve: "P-256",
-  };
-
   const signingKey = await crypto.subtle.importKey(
     "jwk",
     issuerKeyPair.privateKey,
-    { name: "ECDSA", namedCurve: "P-256" },
+    SIGNING_ALGORITHM,
     true,
     ["sign"],
   );
@@ -182,7 +178,7 @@ export async function createSignedCertificate(
   const publicKey = await crypto.subtle.importKey(
     "jwk",
     subjectKeyPair.publicKey,
-    { name: "ECDSA", namedCurve: "P-256" },
+    SIGNING_ALGORITHM,
     true,
     ["verify"],
   );
@@ -191,7 +187,7 @@ export async function createSignedCertificate(
   const notAfter = new Date(notBefore.getTime() + VALIDITY_MS);
 
   const extensions: x509.Extension[] = [
-    new x509.BasicConstraintsExtension(isCA, undefined, true),
+    new x509.BasicConstraintsExtension(isCA, isCA ? 0 : undefined, true),
     new x509.KeyUsagesExtension(
       isCA
         ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.digitalSignature // eslint-disable-line no-bitwise
@@ -201,22 +197,14 @@ export async function createSignedCertificate(
     await x509.SubjectKeyIdentifierExtension.create(publicKey),
   ];
 
-  if (!isCA) {
-    extensions.push(
-      new x509.ExtendedKeyUsageExtension(
-        [x509.ExtendedKeyUsage.serverAuth, x509.ExtendedKeyUsage.clientAuth],
-        false,
-      ),
-    );
-  }
-
   const cert = await x509.X509CertificateGenerator.create({
     extensions,
     issuer: issuerSubject,
     notAfter,
     notBefore,
     publicKey,
-    signingAlgorithm,
+    serialNumber: randomBytes(16).toString("hex"),
+    signingAlgorithm: SIGNING_ALGORITHM,
     signingKey,
     subject: subjectName,
   });
@@ -224,14 +212,9 @@ export async function createSignedCertificate(
   return cert;
 }
 
-/**
- * Returns `true` if any certificate in the given base64-DER array is expired.
- */
-export function hasAnyCertificateExpired(x5cChain: string[]): boolean {
-  return x5cChain.some((cert) => hasX509CertificateExpired(cert));
-}
-
-export function hasX509CertificateExpired(x5c: string | x509.X509Certificate) {
+export function hasX509CertificateExpired(
+  x5c: string | x509.X509Certificate,
+): boolean {
   const certificate =
     typeof x5c === "string" ? new x509.X509Certificate(x5c) : x5c;
   return certificate.notAfter.getTime() < Date.now() - CLOCK_SKEW_TOLERANCE_MS;
@@ -259,11 +242,7 @@ export async function loadCertificate(
   if (!dirCreated) {
     try {
       const certPem = readFileSync(`${certPath}/${filename}`, "utf-8");
-      const certDerBase64 = certPem
-        .replace("-----BEGIN CERTIFICATE-----", "")
-        .replace("-----END CERTIFICATE-----", "")
-        .replace(/\s+/g, "")
-        .trim();
+      const certDerBase64 = pemToBase64Der(certPem);
 
       if (hasX509CertificateExpired(certDerBase64))
         throw new CertificateExpiredError(
@@ -333,6 +312,19 @@ export async function loadOrCreateCertificateWithKey(
     subject,
     extraExtensions,
   );
+}
+
+/**
+ * Strips PEM headers/footers and whitespace, returning the raw base64-DER
+ * string suitable for an x5c array entry.
+ */
+export function pemToBase64Der(pem: string): string {
+  // Single-certificate PEM only. Multi-cert bundles are not supported.
+  return pem
+    .replaceAll("-----BEGIN CERTIFICATE-----", "")
+    .replaceAll("-----END CERTIFICATE-----", "")
+    .replace(/\s+/g, "")
+    .trim();
 }
 
 /**

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -194,7 +194,7 @@ export async function createSignedCertificate(
     new x509.BasicConstraintsExtension(isCA, undefined, true),
     new x509.KeyUsagesExtension(
       isCA
-        ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.digitalSignature
+        ? x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.digitalSignature // eslint-disable-line no-bitwise
         : x509.KeyUsageFlags.digitalSignature,
       true,
     ),

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,30 +1,149 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+import { CertificateExpiredError } from "@/errors";
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { Config, KeyPair } from "@/types";
 
-import { loadCertificate } from "./pem";
+import { createKeys } from "./jwk";
+import {
+  createSignedCertificate,
+  hasAnyCertificateExpired,
+  hasX509CertificateExpired,
+} from "./pem";
+import { ensureDir, loadJwks } from "./utils";
+
+/** Filenames for persisted intermediate artefacts */
+const CA_INTERMEDIATE_JWKS = "ca_intermediate_jwks";
+const CA_INTERMEDIATE_CERT = "ca_intermediate_cert";
+const WALLET_PROVIDER_CERT = "wallet_provider_cert";
 
 /**
- * Loads (or lazily generates and caches on disk) an X.509 certificate for the
- * wallet provider key pair, suitable for use in
- * WalletAttestationOptionsV1_3.signer.x5c.
+ * Strips PEM headers/footers and whitespace, returning the raw base64-DER
+ * string suitable for an x5c array entry.
+ */
+function pemToBase64Der(pem: string): string {
+  return pem
+    .replace("-----BEGIN CERTIFICATE-----", "")
+    .replace("-----END CERTIFICATE-----", "")
+    .replace(/\s+/g, "")
+    .trim();
+}
+
+/**
+ * Loads a persisted base64-DER certificate from disk.
+ * Returns `undefined` if the file does not exist or is expired.
+ */
+function loadCachedCert(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+
+  try {
+    const certPem = readFileSync(filePath, "utf-8");
+    const certDerBase64 = pemToBase64Der(certPem);
+
+    if (hasX509CertificateExpired(certDerBase64)) {
+      throw new CertificateExpiredError(
+        "Certificate has expired and has to be regenerated",
+      );
+    }
+
+    return certDerBase64;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Loads (or lazily generates and caches on disk) the X.509 certificate chain
+ * for the wallet provider key pair, suitable for use in the `x5c` header
+ * of wallet attestations and key attestations.
  *
- * Follows the same lazy-cache pattern as loadCertificate /
- * loadTAJwksWithSelfSignedX5c.
+ * The chain follows the IT-Wallet specification:
+ *
+ *   TA  → signs → CA1  (intermediate, attests KY1)
+ *   KY1 → signs → CA2  (leaf, attests providerKeyPair / KY2)
+ *
+ * Returned array: `[CA2, CA1]` (leaf → root, per x5c / RFC 7517 §4.7).
+ *
+ * Intermediate artefacts (KY1 key pair + CA1 cert) are persisted under
+ * `trust.ca_cert_path`.  The leaf CA2 cert is persisted under
+ * `wallet.backup_storage_path`.
+ *
+ * If either certificate in the chain is expired the entire chain is
+ * regenerated.
  *
  * @param wallet - The wallet configuration section from Config
- * @param providerKeyPair - The provider key pair loaded from backup_storage_path
- * @returns A non-empty tuple of base64-DER certificate strings: [leaf, ...chain]
+ * @param trust - The trust configuration section (provides TA keys + CA cert path)
+ * @param providerKeyPair - The provider key pair loaded from backup_storage_path (KY2)
+ * @returns A non-empty tuple of base64-DER certificate strings: [CA2, CA1]
  */
 export async function loadWalletProviderCertificate(
   wallet: Config["wallet"],
+  trust: Config["trust"],
   providerKeyPair: KeyPair,
 ): Promise<[string, ...string[]]> {
+  const caCertPath = trust.ca_cert_path;
+  const backupPath = wallet.backup_storage_path;
+
+  ensureDir(caCertPath);
+  ensureDir(backupPath);
+
+  const ca1Path = `${caCertPath}/${CA_INTERMEDIATE_CERT}`;
+  const ca2Path = `${backupPath}/${WALLET_PROVIDER_CERT}`;
+
+  // ── Try loading the cached chain ──────────────────────────────────────
+  const cachedCA1 = loadCachedCert(ca1Path);
+  const cachedCA2 = loadCachedCert(ca2Path);
+
+  if (cachedCA1 && cachedCA2 && !hasAnyCertificateExpired([cachedCA2, cachedCA1])) {
+    return [cachedCA2, cachedCA1];
+  }
+
+  // ── Invalidate stale artefacts ────────────────────────────────────────
+  for (const p of [ca1Path, ca2Path]) {
+    if (existsSync(p)) rmSync(p);
+  }
+
+  const intermediateJwksPath = `${caCertPath}/${CA_INTERMEDIATE_JWKS}`;
+  if (existsSync(intermediateJwksPath)) rmSync(intermediateJwksPath);
+
+  // ── Load Trust Anchor key pair ────────────────────────────────────────
+  const taKeyPair = await loadJwks(
+    trust.federation_trust_anchors_jwks_path,
+    "trust_anchor_jwks",
+  );
+
+  // ── Generate intermediate key pair (KY1) ──────────────────────────────
+  const intermediateKeyPair = await createKeys();
+  writeFileSync(intermediateJwksPath, JSON.stringify(intermediateKeyPair));
+
+  // ── CA1: signed by TA, attests KY1 (isCA = true) ─────────────────────
+  const taSubject = trust.certificate_subject;
+  const intermediateSubject = "CN=WalletProvider Intermediate CA";
+
+  const ca1Cert = await createSignedCertificate(
+    taKeyPair,
+    taSubject,
+    intermediateKeyPair,
+    intermediateSubject,
+    true,
+  );
+
+  writeFileSync(ca1Path, ca1Cert.toString("pem"));
+  const ca1Base64 = Buffer.from(ca1Cert.rawData).toString("base64");
+
+  // ── CA2: signed by KY1, attests providerKeyPair / KY2 (leaf) ─────────
   const providerDomain = LOCAL_WP_HOST;
-  const cert = await loadCertificate(
-    wallet.backup_storage_path,
-    "wallet_provider_cert",
+
+  const ca2Cert = await createSignedCertificate(
+    intermediateKeyPair,
+    intermediateSubject,
     providerKeyPair,
     `CN=${providerDomain}`,
+    false,
   );
-  return [cert];
+
+  writeFileSync(ca2Path, ca2Cert.toString("pem"));
+  const ca2Base64 = Buffer.from(ca2Cert.rawData).toString("base64");
+
+  return [ca2Base64, ca1Base64];
 }

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -18,41 +18,6 @@ const CA_INTERMEDIATE_CERT = "ca_intermediate_cert";
 const WALLET_PROVIDER_CERT = "wallet_provider_cert";
 
 /**
- * Strips PEM headers/footers and whitespace, returning the raw base64-DER
- * string suitable for an x5c array entry.
- */
-function pemToBase64Der(pem: string): string {
-  return pem
-    .replace("-----BEGIN CERTIFICATE-----", "")
-    .replace("-----END CERTIFICATE-----", "")
-    .replace(/\s+/g, "")
-    .trim();
-}
-
-/**
- * Loads a persisted base64-DER certificate from disk.
- * Returns `undefined` if the file does not exist or is expired.
- */
-function loadCachedCert(filePath: string): string | undefined {
-  if (!existsSync(filePath)) return undefined;
-
-  try {
-    const certPem = readFileSync(filePath, "utf-8");
-    const certDerBase64 = pemToBase64Der(certPem);
-
-    if (hasX509CertificateExpired(certDerBase64)) {
-      throw new CertificateExpiredError(
-        "Certificate has expired and has to be regenerated",
-      );
-    }
-
-    return certDerBase64;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
  * Loads (or lazily generates and caches on disk) the X.509 certificate chain
  * for the wallet provider key pair, suitable for use in the `x5c` header
  * of wallet attestations and key attestations.
@@ -94,7 +59,11 @@ export async function loadWalletProviderCertificate(
   const cachedCA1 = loadCachedCert(ca1Path);
   const cachedCA2 = loadCachedCert(ca2Path);
 
-  if (cachedCA1 && cachedCA2 && !hasAnyCertificateExpired([cachedCA2, cachedCA1])) {
+  if (
+    cachedCA1 &&
+    cachedCA2 &&
+    !hasAnyCertificateExpired([cachedCA2, cachedCA1])
+  ) {
     return [cachedCA2, cachedCA1];
   }
 
@@ -102,9 +71,6 @@ export async function loadWalletProviderCertificate(
   for (const p of [ca1Path, ca2Path]) {
     if (existsSync(p)) rmSync(p);
   }
-
-  const intermediateJwksPath = `${caCertPath}/${CA_INTERMEDIATE_JWKS}`;
-  if (existsSync(intermediateJwksPath)) rmSync(intermediateJwksPath);
 
   // ── Load Trust Anchor key pair ────────────────────────────────────────
   const taKeyPair = await loadJwks(
@@ -114,6 +80,9 @@ export async function loadWalletProviderCertificate(
 
   // ── Generate intermediate key pair (KY1) ──────────────────────────────
   const intermediateKeyPair = await createKeys();
+  const intermediateJwksPath = `${caCertPath}/${CA_INTERMEDIATE_JWKS}`;
+
+  if (existsSync(intermediateJwksPath)) rmSync(intermediateJwksPath);
   writeFileSync(intermediateJwksPath, JSON.stringify(intermediateKeyPair));
 
   // ── CA1: signed by TA, attests KY1 (isCA = true) ─────────────────────
@@ -146,4 +115,39 @@ export async function loadWalletProviderCertificate(
   const ca2Base64 = Buffer.from(ca2Cert.rawData).toString("base64");
 
   return [ca2Base64, ca1Base64];
+}
+
+/**
+ * Loads a persisted base64-DER certificate from disk.
+ * Returns `undefined` if the file does not exist or is expired.
+ */
+function loadCachedCert(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+
+  try {
+    const certPem = readFileSync(filePath, "utf-8");
+    const certDerBase64 = pemToBase64Der(certPem);
+
+    if (hasX509CertificateExpired(certDerBase64)) {
+      throw new CertificateExpiredError(
+        "Certificate has expired and has to be regenerated",
+      );
+    }
+
+    return certDerBase64;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Strips PEM headers/footers and whitespace, returning the raw base64-DER
+ * string suitable for an x5c array entry.
+ */
+function pemToBase64Der(pem: string): string {
+  return pem
+    .replace("-----BEGIN CERTIFICATE-----", "")
+    .replace("-----END CERTIFICATE-----", "")
+    .replace(/\s+/g, "")
+    .trim();
 }

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -82,7 +82,6 @@ export async function loadWalletProviderCertificate(
   const intermediateKeyPair = await createKeys();
   const intermediateJwksPath = `${caCertPath}/${CA_INTERMEDIATE_JWKS}`;
 
-  if (existsSync(intermediateJwksPath)) rmSync(intermediateJwksPath);
   writeFileSync(intermediateJwksPath, JSON.stringify(intermediateKeyPair));
 
   // ── CA1: signed by TA, attests KY1 (isCA = true) ─────────────────────

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -1,14 +1,14 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
-import { CertificateExpiredError } from "@/errors";
 import { LOCAL_WP_HOST } from "@/servers/wp-server";
 import { Config, KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
 import {
   createSignedCertificate,
-  hasAnyCertificateExpired,
   hasX509CertificateExpired,
+  pemToBase64Der,
 } from "./pem";
 import { ensureDir, loadJwks } from "./utils";
 
@@ -52,18 +52,14 @@ export async function loadWalletProviderCertificate(
   ensureDir(caCertPath);
   ensureDir(backupPath);
 
-  const ca1Path = `${caCertPath}/${CA_INTERMEDIATE_CERT}`;
-  const ca2Path = `${backupPath}/${WALLET_PROVIDER_CERT}`;
+  const ca1Path = path.resolve(path.join(caCertPath, CA_INTERMEDIATE_CERT));
+  const ca2Path = path.resolve(path.join(backupPath, WALLET_PROVIDER_CERT));
 
   // ── Try loading the cached chain ──────────────────────────────────────
   const cachedCA1 = loadCachedCert(ca1Path);
   const cachedCA2 = loadCachedCert(ca2Path);
 
-  if (
-    cachedCA1 &&
-    cachedCA2 &&
-    !hasAnyCertificateExpired([cachedCA2, cachedCA1])
-  ) {
+  if (cachedCA1 && cachedCA2) {
     return [cachedCA2, cachedCA1];
   }
 
@@ -80,7 +76,9 @@ export async function loadWalletProviderCertificate(
 
   // ── Generate intermediate key pair (KY1) ──────────────────────────────
   const intermediateKeyPair = await createKeys();
-  const intermediateJwksPath = `${caCertPath}/${CA_INTERMEDIATE_JWKS}`;
+  const intermediateJwksPath = path.resolve(
+    path.join(caCertPath, CA_INTERMEDIATE_JWKS),
+  );
 
   writeFileSync(intermediateJwksPath, JSON.stringify(intermediateKeyPair));
 
@@ -123,30 +121,18 @@ export async function loadWalletProviderCertificate(
 function loadCachedCert(filePath: string): string | undefined {
   if (!existsSync(filePath)) return undefined;
 
+  let certPem: string;
   try {
-    const certPem = readFileSync(filePath, "utf-8");
-    const certDerBase64 = pemToBase64Der(certPem);
+    certPem = readFileSync(filePath, "utf-8");
+  } catch (e) {
+    const err = e as { code?: string };
+    if (err.code === "ENOENT") return undefined;
 
-    if (hasX509CertificateExpired(certDerBase64)) {
-      throw new CertificateExpiredError(
-        "Certificate has expired and has to be regenerated",
-      );
-    }
-
-    return certDerBase64;
-  } catch {
-    return undefined;
+    throw e;
   }
-}
 
-/**
- * Strips PEM headers/footers and whitespace, returning the raw base64-DER
- * string suitable for an x5c array entry.
- */
-function pemToBase64Der(pem: string): string {
-  return pem
-    .replace("-----BEGIN CERTIFICATE-----", "")
-    .replace("-----END CERTIFICATE-----", "")
-    .replace(/\s+/g, "")
-    .trim();
+  const certDerBase64 = pemToBase64Der(certPem);
+  if (hasX509CertificateExpired(certDerBase64)) return undefined;
+
+  return certDerBase64;
 }

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -117,6 +117,7 @@ export class CredentialRequestDefaultStep extends StepFlow {
 
     const x5c = await loadWalletProviderCertificate(
       this.config.wallet,
+      this.config.trust,
       providerKey,
     );
 

--- a/tests/conformance/presentation/authorization-request.presentation.spec.ts
+++ b/tests/conformance/presentation/authorization-request.presentation.spec.ts
@@ -243,8 +243,11 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
       // A JWE compact serialization has 5 base64url-encoded parts: header.ek.iv.ciphertext.tag
       const parts = validJarmJwe.split(".");
       expect(parts.length).toBe(5);
+
       // Tamper with the authentication tag to invalidate integrity
-      const tag = parts[4]!;
+      const tag = parts[4];
+      if (!tag) throw new Error("received malformed jarm jwe");
+
       const tamperedTag =
         tag.slice(0, -4) + (tag.endsWith("AAAA") ? "BBBB" : "AAAA");
       parts[4] = tamperedTag;
@@ -283,7 +286,10 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
       );
       expect(authResult.success).toBe(true);
 
-      const { requestObject, responseUri } = authResult.response!;
+      if (!authResult.response)
+        throw new Error("auth request was not successful");
+
+      const { requestObject, responseUri } = authResult.response;
 
       log.info(
         "→ Building JARM with a wrong nonce via createAuthorizationResponse...",
@@ -316,8 +322,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
         requestObject: tamperedRequestObject,
         rpJwks: { jwks: metadata.jwks },
         vp_token:
-          authResult.response!.authorizationResponse
-            .authorizationResponsePayload.vp_token,
+          authResult.response.authorizationResponse.authorizationResponsePayload
+            .vp_token,
       });
 
       log.info("→ Posting JARM with wrong nonce to response_uri...");
@@ -443,7 +449,9 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
       const parts = validJarmJwe.split(".");
       expect(parts.length).toBe(5);
       // Corrupt the ciphertext (4th part, index 3)
-      const ciphertext = parts[3]!;
+      const ciphertext = parts[3];
+      if (!ciphertext) throw new Error("received malformed jarm jwe");
+
       parts[3] = ciphertext.slice(0, 4) + "TAMPERED" + ciphertext.slice(12);
       const corruptedJwe = parts.join(".");
 


### PR DESCRIPTION
#### Motivation and Context
This PR updates the Wallet Provider certificate generation logic to align with the IT-Wallet V1.3 specification, which requires a proper X.509 certificate chain rather than a simple self-signed certificate. 

The implementation introduces a two-tier certificate hierarchy:
   1. Intermediate CA (CA1): Generated dynamically and signed by the Trust Anchor (TA). This certificate attests an intermediate key pair.
   2. Leaf Certificate (CA2): Signed by the Intermediate CA. This certificate attests the Wallet Provider's key pair.

JIRA Ticket: WLEO-1154