### PR TITLE
fix: linting, formatting and types checking issues resolution

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,37 @@
+name: "Code Review"
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch: {}
+
+jobs:
+  code_review:
+    timeout-minutes: 5
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          fetch-depth: 2
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda #v4.1.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org/"
+          node-version-file: ".node-version"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: "Code review"
+        run: pnpm code-review

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
           node-version-file: ".node-version"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Code review"
         run: pnpm code-review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for agentic coding agents working in this repository.
+Guidance for agentic coding agents weorking in this repository.
 
 ## Project Overview
 
@@ -21,7 +21,6 @@ pnpm format:check          # Prettier check only
 pnpm lint                  # ESLint --fix
 pnpm lint:check            # ESLint check only
 pnpm pre-commit            # format + lint (run before every commit)
-pnpm pre-push              # format + lint + type-check + all tests
 
 # Tests
 pnpm test                  # All tests (vitest run)
@@ -139,12 +138,12 @@ OrchestratorError (base)            code: string
 
 When to use each class:
 
-| Situation | Class | `code` |
-| --------- | ----- | ------ |
-| A step's result is missing a required field | `StepOutputError(stepTag, missingField)` | `"STEP_OUTPUT_MISSING"` |
-| Issuer metadata lacks a required field | `IssuerMetadataError(missingField, parentObject, requiredFor)` | `"ISSUER_METADATA_MISSING_FIELD"` |
-| Requested credential ID not supported by issuer or not in offer | `CredentialConfigurationError(requestedId, reason, availableIds)` | `"CREDENTIAL_CONFIGURATION_MISMATCH"` |
-| Any other orchestrator-level error with no dedicated class | `OrchestratorError(message, "SPECIFIC_CODE")` | e.g. `"CREDENTIAL_CONFIGURATION_ID_UNRESOLVED"`, `"ENTITY_STATEMENT_CLAIMS_MISSING"`, `"AUTHORIZATION_RESPONSE_MISSING"` |
+| Situation                                                       | Class                                                             | `code`                                                                                                                   |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| A step's result is missing a required field                     | `StepOutputError(stepTag, missingField)`                          | `"STEP_OUTPUT_MISSING"`                                                                                                  |
+| Issuer metadata lacks a required field                          | `IssuerMetadataError(missingField, parentObject, requiredFor)`    | `"ISSUER_METADATA_MISSING_FIELD"`                                                                                        |
+| Requested credential ID not supported by issuer or not in offer | `CredentialConfigurationError(requestedId, reason, availableIds)` | `"CREDENTIAL_CONFIGURATION_MISMATCH"`                                                                                    |
+| Any other orchestrator-level error with no dedicated class      | `OrchestratorError(message, "SPECIFIC_CODE")`                     | e.g. `"CREDENTIAL_CONFIGURATION_ID_UNRESOLVED"`, `"ENTITY_STATEMENT_CLAIMS_MISSING"`, `"AUTHORIZATION_RESPONSE_MISSING"` |
 
 Rules:
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:check": "eslint \"{src,tests}/**/*.{js,ts}\"",
     "pre-commit": "pnpm format && pnpm lint",
     "pre-push": "pnpm pre-commit && pnpm types:check && pnpm test",
+    "prepare": "husky",
     "code-review": "pnpm types:check && pnpm lint:check && pnpm format:check && pnpm -r build && pnpm test",
     "test:issuance": "vitest run --config vitest.issuance.config.mjs",
     "test:issuance:ui": "vitest --config vitest.issuance.config.mjs --ui",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
     "lint": "eslint --fix \"{src,tests}/**/*.{js,ts}\"",
     "lint:check": "eslint \"{src,tests}/**/*.{js,ts}\"",
     "pre-commit": "pnpm format && pnpm lint && pnpm types:check",
-    "pre-push": "pnpm pre-commit && pnpm types:check && pnpm test",
     "prepare": "husky",
-    "code-review": "pnpm types:check && pnpm lint:check && pnpm format:check && pnpm -r build && pnpm test",
+    "code-review": "pnpm types:check && pnpm lint:check && pnpm format:check && pnpm -r build",
     "test:issuance": "vitest run --config vitest.issuance.config.mjs",
     "test:issuance:ui": "vitest --config vitest.issuance.config.mjs --ui",
     "test:presentation": "vitest run --config vitest.presentation.config.mjs"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format:check": "prettier --check \"{src,tests}/**/*.{js,ts}\"",
     "lint": "eslint --fix \"{src,tests}/**/*.{js,ts}\"",
     "lint:check": "eslint \"{src,tests}/**/*.{js,ts}\"",
-    "pre-commit": "pnpm format && pnpm lint",
+    "pre-commit": "pnpm format && pnpm lint && pnpm types:check",
     "pre-push": "pnpm pre-commit && pnpm types:check && pnpm test",
     "prepare": "husky",
     "code-review": "pnpm types:check && pnpm lint:check && pnpm format:check && pnpm -r build && pnpm test",

--- a/src/functions/V1_0/mock-credentials.ts
+++ b/src/functions/V1_0/mock-credentials.ts
@@ -14,10 +14,6 @@ import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
 
-interface MutableIssuerAuthPayload {
-  payload: Uint8Array;
-}
-
 export async function buildIssuerEntityConfiguration_V1_0(
   metadata: {
     iss: string;
@@ -85,9 +81,9 @@ export async function buildMockMdlMdoc_V1_0(
     ),
   );
   issuerSigned.issuerAuth[2] = payloadWithStatus;
-  const parsedIssuerAuth = document.issuerSigned
-    .issuerAuth as unknown as MutableIssuerAuthPayload;
-  parsedIssuerAuth.payload = payloadWithStatus;
+  Object.assign(document.issuerSigned.issuerAuth, {
+    payload: payloadWithStatus,
+  });
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<

--- a/src/functions/V1_0/mock-credentials.ts
+++ b/src/functions/V1_0/mock-credentials.ts
@@ -14,6 +14,10 @@ import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
 
+interface MutableIssuerAuthPayload {
+  payload: Uint8Array;
+}
+
 export async function buildIssuerEntityConfiguration_V1_0(
   metadata: {
     iss: string;
@@ -81,8 +85,9 @@ export async function buildMockMdlMdoc_V1_0(
     ),
   );
   issuerSigned.issuerAuth[2] = payloadWithStatus;
-  const parsed = document as any;
-  parsed.issuerSigned.issuerAuth.payload = payloadWithStatus;
+  const parsedIssuerAuth = document.issuerSigned
+    .issuerAuth as unknown as MutableIssuerAuthPayload;
+  parsedIssuerAuth.payload = payloadWithStatus;
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<
@@ -103,7 +108,7 @@ export async function buildMockMdlMdoc_V1_0(
 
   return {
     compact,
-    parsed,
+    parsed: document,
     typ: "mso_mdoc",
   };
 }

--- a/src/functions/V1_3/mock-credentials.ts
+++ b/src/functions/V1_3/mock-credentials.ts
@@ -15,10 +15,6 @@ import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
 
-interface MutableIssuerAuthPayload {
-  payload: Uint8Array;
-}
-
 export async function buildIssuerEntityConfiguration_V1_3(
   metadata: {
     iss: string;
@@ -94,9 +90,9 @@ export async function buildMockMdlMdoc_V1_3(
     ),
   );
   issuerSigned.issuerAuth[2] = payloadWithStatus;
-  const parsedIssuerAuth = document.issuerSigned
-    .issuerAuth as unknown as MutableIssuerAuthPayload;
-  parsedIssuerAuth.payload = payloadWithStatus;
+  Object.assign(document.issuerSigned.issuerAuth, {
+    payload: payloadWithStatus,
+  });
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<

--- a/src/functions/V1_3/mock-credentials.ts
+++ b/src/functions/V1_3/mock-credentials.ts
@@ -15,6 +15,10 @@ import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
 
+interface MutableIssuerAuthPayload {
+  payload: Uint8Array;
+}
+
 export async function buildIssuerEntityConfiguration_V1_3(
   metadata: {
     iss: string;
@@ -90,8 +94,9 @@ export async function buildMockMdlMdoc_V1_3(
     ),
   );
   issuerSigned.issuerAuth[2] = payloadWithStatus;
-  const parsed = document as any;
-  parsed.issuerSigned.issuerAuth.payload = payloadWithStatus;
+  const parsedIssuerAuth = document.issuerSigned
+    .issuerAuth as unknown as MutableIssuerAuthPayload;
+  parsedIssuerAuth.payload = payloadWithStatus;
 
   const nameSpaces = new Map<string, Tagged[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -1,7 +1,5 @@
 import {
   WalletAttestationOptions,
-  WalletAttestationOptionsV1_0,
-  WalletAttestationOptionsV1_3,
   WalletProvider,
 } from "@pagopa/io-wallet-oid4vci";
 import {
@@ -113,7 +111,7 @@ const buildAttestationOptions = async (
 
   switch (wallet.wallet_version) {
     case ItWalletSpecsVersion.V1_0: {
-      const attestationOptions: WalletAttestationOptionsV1_0 = {
+      const attestationOptions: WalletAttestationOptions = {
         ...commonOptions,
         authenticatorAssuranceLevel: "substantial",
         signer: { ...signerBase, method: "federation", trustChain },
@@ -122,7 +120,7 @@ const buildAttestationOptions = async (
     }
     case ItWalletSpecsVersion.V1_3: {
       const x5c = await loadWalletProviderCertificate(wallet, providerKeyPair);
-      const attestationOptions: WalletAttestationOptionsV1_3 = {
+      const attestationOptions: WalletAttestationOptions = {
         ...commonOptions,
         signer: { ...signerBase, method: "x5c", trustChain, x5c },
       };

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -151,7 +151,7 @@ export async function parseCredentialStatus(
     );
 
   switch (credential.typ) {
-    case "dc+sd-jwt":
+    case "dc+sd-jwt": {
       const sdJwtPayload = credential.parsed.jwt.payload;
       if (!sdJwtPayload || typeof sdJwtPayload !== "object")
         throw new Error("parsed sd-jwt has empty or malformed payload");
@@ -159,7 +159,8 @@ export async function parseCredentialStatus(
       if (!sdJwtPayload.status) return null;
 
       return sdJwtPayload.status as StatusClaim;
-    case "mso_mdoc":
+    }
+    case "mso_mdoc": {
       const mdocPayloadTag = decode(
         credential.parsed.issuerSigned.issuerAuth.payload,
       );
@@ -177,6 +178,7 @@ export async function parseCredentialStatus(
       if (!mdocPayload.status) return null;
 
       return mdocPayload.status as StatusClaim;
+    }
     default:
       return null;
   }

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -33,6 +33,10 @@ export interface CliOptions {
   unsafeTls?: boolean;
 }
 
+type ConfigSectionBuilder<TSection> = (
+  options: CliOptions,
+) => Partial<TSection>;
+
 /**
  * Type for parsed INI configuration before transformation
  * The ini parser returns a structure that needs to be transformed to match Config type
@@ -167,112 +171,120 @@ export function readPackageVersion(): string {
  */
 function cliOptionsToConfig(options: CliOptions): Partial<Config> {
   const partialConfig: Partial<Config> = {};
+  const issuance = buildIssuanceConfig(options);
+  const presentation = buildPresentationConfig(options);
+  const network = buildNetworkConfig(options);
+  const logging = buildLoggingConfig(options);
+  const trustAnchor = buildTrustAnchorConfig(options);
+  const stepsMapping = buildStepsMappingConfig(options);
 
-  // Map CLI options to config structure
-  if (
-    options.credentialIssuerUri ||
-    options.credentialOfferUri ||
-    options.credentialTypes ||
-    options.saveCredential !== undefined ||
-    options.issuanceTestsDir ||
-    options.issuanceCertificateSubject
-  ) {
-    const issuance: Partial<Config["issuance"]> = {};
-    if (options.credentialIssuerUri) {
-      issuance.url = options.credentialIssuerUri;
-    }
-    if (options.credentialOfferUri) {
-      issuance.credential_offer_uri = options.credentialOfferUri;
-    }
-    if (options.credentialTypes) {
-      issuance.credential_types = options.credentialTypes
-        .split(",")
-        .map((t) => t.trim())
-        .filter((t) => t.length > 0);
-    }
-    if (options.saveCredential !== undefined) {
-      issuance.save_credential = options.saveCredential;
-    }
-    if (options.issuanceTestsDir) {
-      issuance.tests_dir = options.issuanceTestsDir;
-    }
-    if (options.issuanceCerificateSubject) {
-      issuance.certificate_subject = options.issuanceCertificateSubject;
-    }
+  if (hasConfigValues<Config["issuance"]>(issuance)) {
     partialConfig.issuance = issuance as Config["issuance"];
   }
-  if (options.presentationAuthorizeUri || options.presentationTestsDir) {
-    const presentation: Partial<Config["presentation"]> = {};
-    if (options.presentationAuthorizeUri) {
-      presentation.authorize_request_url = options.presentationAuthorizeUri;
-    }
-    if (options.presentationTestsDir) {
-      presentation.tests_dir = options.presentationTestsDir;
-    }
+  if (hasConfigValues<Config["presentation"]>(presentation)) {
     partialConfig.presentation = presentation as Config["presentation"];
   }
-
-  if (
-    options.bindAddress !== undefined ||
-    options.timeout !== undefined ||
-    options.maxRetries !== undefined ||
-    options.unsafeTls !== undefined
-  ) {
-    const network: Partial<Config["network"]> = {};
-    if (options.bindAddress !== undefined) {
-      network.bind_address = options.bindAddress;
-    }
-    if (options.timeout !== undefined) {
-      network.timeout = options.timeout;
-    }
-    if (options.maxRetries !== undefined) {
-      network.max_retries = options.maxRetries;
-    }
-    if (options.unsafeTls !== undefined) {
-      network.tls_reject_unauthorized = !options.unsafeTls;
-    }
+  if (hasConfigValues<Config["network"]>(network)) {
     partialConfig.network = network as Config["network"];
   }
-
-  if (options.logLevel || options.logFile) {
-    const logging: Partial<Config["logging"]> = {};
-    if (options.logLevel) {
-      logging.log_level = options.logLevel;
-    }
-    if (options.logFile) {
-      logging.log_file = options.logFile;
-    }
+  if (hasConfigValues<Config["logging"]>(logging)) {
     partialConfig.logging = logging as Config["logging"];
   }
-
-  if (options.port !== undefined || options.trustAnchorCertDir !== undefined) {
-    const trustAnchor: Partial<Config["trust_anchor"]> = {};
-    if (options.port !== undefined) {
-      trustAnchor.port = options.port;
-    }
-    if (options.trustAnchorCertDir !== undefined) {
-      trustAnchor.tls_cert_dir = options.trustAnchorCertDir;
-    }
+  if (hasConfigValues<Config["trust_anchor"]>(trustAnchor)) {
     partialConfig.trust_anchor = trustAnchor as Config["trust_anchor"];
   }
-
-  if (options.stepsMapping) {
-    const mappings: Record<string, string> = {};
-    const pairs = options.stepsMapping.split(",");
-    for (const pair of pairs) {
-      const [key, value] = pair.split("=").map((s) => s.trim());
-      if (key && value) {
-        mappings[key] = value;
-      }
-    }
-    if (Object.keys(mappings).length > 0) {
-      partialConfig.steps_mapping = {
-        mapping: mappings,
-      };
-    }
+  if (stepsMapping) {
+    partialConfig.steps_mapping = stepsMapping;
   }
 
-  return partialConfig as Partial<Config>;
+  return partialConfig;
+}
+
+function hasConfigValues<TSection extends object>(
+  section: Partial<TSection>,
+): section is Partial<TSection> {
+  return Object.keys(section).length > 0;
+}
+
+const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
+  options,
+) => ({
+  ...(options.credentialIssuerUri && { url: options.credentialIssuerUri }),
+  ...(options.credentialOfferUri && {
+    credential_offer_uri: options.credentialOfferUri,
+  }),
+  ...(options.credentialTypes && {
+    credential_types: options.credentialTypes
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0),
+  }),
+  ...(options.saveCredential !== undefined && {
+    save_credential: options.saveCredential,
+  }),
+  ...(options.issuanceTestsDir && { tests_dir: options.issuanceTestsDir }),
+  ...(options.issuanceCertificateSubject && {
+    certificate_subject: options.issuanceCertificateSubject,
+  }),
+});
+
+const buildPresentationConfig: ConfigSectionBuilder<Config["presentation"]> = (
+  options,
+) => ({
+  ...(options.presentationAuthorizeUri && {
+    authorize_request_url: options.presentationAuthorizeUri,
+  }),
+  ...(options.presentationTestsDir && {
+    tests_dir: options.presentationTestsDir,
+  }),
+});
+
+const buildNetworkConfig: ConfigSectionBuilder<Config["network"]> = (
+  options,
+) => ({
+  ...(options.bindAddress !== undefined && {
+    bind_address: options.bindAddress,
+  }),
+  ...(options.timeout !== undefined && { timeout: options.timeout }),
+  ...(options.maxRetries !== undefined && {
+    max_retries: options.maxRetries,
+  }),
+  ...(options.unsafeTls !== undefined && {
+    tls_reject_unauthorized: !options.unsafeTls,
+  }),
+});
+
+const buildLoggingConfig: ConfigSectionBuilder<Config["logging"]> = (
+  options,
+) => ({
+  ...(options.logLevel && { log_level: options.logLevel }),
+  ...(options.logFile && { log_file: options.logFile }),
+});
+
+const buildTrustAnchorConfig: ConfigSectionBuilder<Config["trust_anchor"]> = (
+  options,
+) => ({
+  ...(options.port !== undefined && { port: options.port }),
+  ...(options.trustAnchorCertDir !== undefined && {
+    tls_cert_dir: options.trustAnchorCertDir,
+  }),
+});
+
+function buildStepsMappingConfig(
+  options: CliOptions,
+): Config["steps_mapping"] | undefined {
+  if (!options.stepsMapping) {
+    return;
+  }
+
+  const mappings = Object.fromEntries(
+    options.stepsMapping
+      .split(",")
+      .map((pair) => pair.split("=").map((s) => s.trim()))
+      .filter((pair): pair is [string, string] => Boolean(pair[0] && pair[1])),
+  );
+
+  return Object.keys(mappings).length > 0 ? { mapping: mappings } : undefined;
 }
 
 /**
@@ -308,6 +320,17 @@ function loadIniFile(filePath: string): null | Partial<Config> {
   }
 }
 
+function readBooleanEnv(
+  options: CliOptions,
+  optionKey: keyof CliOptions,
+  envKey: string,
+): void {
+  const value = process.env[envKey];
+  if (value) {
+    options[optionKey] = value === "true";
+  }
+}
+
 /**
  * Reads CLI options from environment variables.
  *
@@ -320,71 +343,63 @@ function loadIniFile(filePath: string): null | Partial<Config> {
 function readCliOptionsFromEnv(): CliOptions {
   const options: CliOptions = {};
 
-  if (process.env.CONFIG_FILE_INI) {
-    options.fileIni = process.env.CONFIG_FILE_INI;
-  }
-  if (process.env.CONFIG_CREDENTIAL_ISSUER_URI) {
-    options.credentialIssuerUri = process.env.CONFIG_CREDENTIAL_ISSUER_URI;
-  }
-  if (process.env.CONFIG_CREDENTIAL_OFFER_URI) {
-    options.credentialOfferUri = process.env.CONFIG_CREDENTIAL_OFFER_URI;
-  }
-  if (process.env.CONFIG_PRESENTATION_AUTHORIZE_URI) {
-    options.presentationAuthorizeUri =
-      process.env.CONFIG_PRESENTATION_AUTHORIZE_URI;
-  }
-  if (process.env.CONFIG_CREDENTIAL_TYPES) {
-    options.credentialTypes = process.env.CONFIG_CREDENTIAL_TYPES;
-  }
-  if (process.env.CONFIG_TIMEOUT) {
-    const parsed = parseInt(process.env.CONFIG_TIMEOUT, 10);
-    if (!isNaN(parsed)) {
-      options.timeout = parsed;
-    }
-  }
-  if (process.env.CONFIG_MAX_RETRIES) {
-    const parsed = parseInt(process.env.CONFIG_MAX_RETRIES, 10);
-    if (!isNaN(parsed)) {
-      options.maxRetries = parsed;
-    }
-  }
-  if (process.env.CONFIG_LOG_LEVEL) {
-    options.logLevel = process.env.CONFIG_LOG_LEVEL;
-  }
-  if (process.env.CONFIG_LOG_FILE) {
-    options.logFile = process.env.CONFIG_LOG_FILE;
-  }
-  if (process.env.CONFIG_PORT) {
-    const parsed = parseInt(process.env.CONFIG_PORT, 10);
-    if (!isNaN(parsed)) {
-      options.port = parsed;
-    }
-  }
-  if (process.env.CONFIG_SAVE_CREDENTIAL) {
-    options.saveCredential = process.env.CONFIG_SAVE_CREDENTIAL === "true";
-  }
-  if (process.env.CONFIG_ISSUANCE_TESTS_DIR) {
-    options.issuanceTestsDir = process.env.CONFIG_ISSUANCE_TESTS_DIR;
-  }
-  if (process.env.CONFIG_ISSUANCE_CERTIFICATE_SUBJECT) {
-    options.issuanceCertificateSubject =
-      process.env.CONFIG_ISSUANCE_CERTIFICATE_SUBJECT;
-  }
-  if (process.env.CONFIG_PRESENTATION_TESTS_DIR) {
-    options.presentationTestsDir = process.env.CONFIG_PRESENTATION_TESTS_DIR;
-  }
-  if (process.env.CONFIG_STEPS_MAPPING) {
-    options.stepsMapping = process.env.CONFIG_STEPS_MAPPING;
-  }
-  if (process.env.CONFIG_UNSAFE_TLS) {
-    options.unsafeTls = process.env.CONFIG_UNSAFE_TLS === "true";
-  }
-  if (process.env.CONFIG_TRUST_ANCHOR_CERT_DIR) {
-    options.trustAnchorCertDir = process.env.CONFIG_TRUST_ANCHOR_CERT_DIR;
-  }
-  if (process.env.OIDF_SERVERS_BIND_ADDRESS) {
-    options.bindAddress = process.env.OIDF_SERVERS_BIND_ADDRESS;
-  }
+  readStringEnv(options, "fileIni", "CONFIG_FILE_INI");
+  readStringEnv(options, "credentialIssuerUri", "CONFIG_CREDENTIAL_ISSUER_URI");
+  readStringEnv(options, "credentialOfferUri", "CONFIG_CREDENTIAL_OFFER_URI");
+  readStringEnv(
+    options,
+    "presentationAuthorizeUri",
+    "CONFIG_PRESENTATION_AUTHORIZE_URI",
+  );
+  readStringEnv(options, "credentialTypes", "CONFIG_CREDENTIAL_TYPES");
+  readNumberEnv(options, "timeout", "CONFIG_TIMEOUT");
+  readNumberEnv(options, "maxRetries", "CONFIG_MAX_RETRIES");
+  readStringEnv(options, "logLevel", "CONFIG_LOG_LEVEL");
+  readStringEnv(options, "logFile", "CONFIG_LOG_FILE");
+  readNumberEnv(options, "port", "CONFIG_PORT");
+  readBooleanEnv(options, "saveCredential", "CONFIG_SAVE_CREDENTIAL");
+  readStringEnv(options, "issuanceTestsDir", "CONFIG_ISSUANCE_TESTS_DIR");
+  readStringEnv(
+    options,
+    "issuanceCertificateSubject",
+    "CONFIG_ISSUANCE_CERTIFICATE_SUBJECT",
+  );
+  readStringEnv(
+    options,
+    "presentationTestsDir",
+    "CONFIG_PRESENTATION_TESTS_DIR",
+  );
+  readStringEnv(options, "stepsMapping", "CONFIG_STEPS_MAPPING");
+  readBooleanEnv(options, "unsafeTls", "CONFIG_UNSAFE_TLS");
+  readStringEnv(options, "trustAnchorCertDir", "CONFIG_TRUST_ANCHOR_CERT_DIR");
+  readStringEnv(options, "bindAddress", "OIDF_SERVERS_BIND_ADDRESS");
 
   return options;
+}
+
+function readNumberEnv(
+  options: CliOptions,
+  optionKey: keyof CliOptions,
+  envKey: string,
+): void {
+  const value = process.env[envKey];
+  if (!value) {
+    return;
+  }
+
+  const parsed = parseInt(value, 10);
+  if (!isNaN(parsed)) {
+    options[optionKey] = parsed;
+  }
+}
+
+function readStringEnv(
+  options: CliOptions,
+  optionKey: keyof CliOptions,
+  envKey: string,
+): void {
+  const value = process.env[envKey];
+  if (value) {
+    options[optionKey] = value;
+  }
 }

--- a/src/logic/mdoc.ts
+++ b/src/logic/mdoc.ts
@@ -15,6 +15,12 @@ import { DcqlQuery } from "dcql";
 
 import { issuerSignedSchema, VpTokenOptions } from "@/types";
 
+interface DcqlMdocClaim {
+  claim_name?: string;
+  namespace?: string;
+  path?: string[];
+}
+
 /**
  * Creates a Verifiable Presentation (VP) token in mdoc format.
  *
@@ -134,9 +140,10 @@ function convertDcqlToPresentationDefinition(
   }
 
   // Extract namespaces and elements from claims
+  const claims = credentialQuery.claims as readonly DcqlMdocClaim[] | undefined;
   const fields =
-    credentialQuery.claims
-      ?.map((claim: any) => {
+    claims
+      ?.map((claim) => {
         if ((!claim.namespace || !claim.claim_name) && !claim.path) {
           return null;
         }
@@ -144,7 +151,7 @@ function convertDcqlToPresentationDefinition(
         return {
           intent_to_retain: true,
           path: claim.path
-            ? [claim.path.map((p: string) => `['${p}']`).join("")]
+            ? [claim.path.map((p) => `['${p}']`).join("")]
             : [`['${claim.namespace}']`, `['${claim.claim_name}']`],
         };
       })

--- a/src/logic/pem.ts
+++ b/src/logic/pem.ts
@@ -257,6 +257,10 @@ export async function loadOrCreateCertificateWithKey(
 async function privateKeyToPem(key: CryptoKey): Promise<string> {
   const exported = await crypto.subtle.exportKey("pkcs8", key);
   const b64 = Buffer.from(exported).toString("base64");
-  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  const chunks = b64.match(/.{1,64}/g);
+  if (!chunks) {
+    throw new Error("Unable to export empty private key");
+  }
+  const lines = chunks.join("\n");
   return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
 }

--- a/src/step/issuance/authorize-step.ts
+++ b/src/step/issuance/authorize-step.ts
@@ -102,7 +102,10 @@ export class AuthorizeDefaultStep extends StepFlow {
         config: this.ioWalletSdkConfig,
         requestObjectJwt,
       });
-      log.debug("Parsed Authorize Request:", JSON.stringify(parsedAuthorizeRequest, null, 2));
+      log.debug(
+        "Parsed Authorize Request:",
+        JSON.stringify(parsedAuthorizeRequest, null, 2),
+      );
 
       const requestObject = parsedAuthorizeRequest.payload;
       const responseUri = requestObject.response_uri;
@@ -171,7 +174,10 @@ export class AuthorizeDefaultStep extends StepFlow {
       const authorizationResponse = await createAuthorizationResponse(
         createAuthorizationResponseOptions,
       );
-      log.debug("Authorization Response created:", JSON.stringify(authorizationResponse, null, 2));
+      log.debug(
+        "Authorization Response created:",
+        JSON.stringify(authorizationResponse, null, 2),
+      );
       if (!authorizationResponse.jarm) {
         log.error("Failed to create authorization response JARM");
         throw new Error("Failed to create authorization response JARM");
@@ -197,7 +203,10 @@ export class AuthorizeDefaultStep extends StepFlow {
       const authorizeResponse = await sendAuthorizationResponseAndExtractCode(
         sendAuthorizationResponseAndExtractCodeOptions,
       );
-      log.debug("Authorize response extracted code:", JSON.stringify(authorizeResponse, null, 2));
+      log.debug(
+        "Authorize response extracted code:",
+        JSON.stringify(authorizeResponse, null, 2),
+      );
 
       return {
         authorizeResponse,

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -163,7 +163,10 @@ export class CredentialRequestDefaultStep extends StepFlow {
         options,
         credentialKeyPair,
       );
-      log.debug("Credential Request:", JSON.stringify(credentialRequest, null, 2));
+      log.debug(
+        "Credential Request:",
+        JSON.stringify(credentialRequest, null, 2),
+      );
 
       log.info("Generating DPoP...");
       const dpop =
@@ -183,7 +186,10 @@ export class CredentialRequestDefaultStep extends StepFlow {
         credentialRequest,
         dpop,
       );
-      log.debug("Credential Response:", JSON.stringify(credentialResponse, null, 2));
+      log.debug(
+        "Credential Response:",
+        JSON.stringify(credentialResponse, null, 2),
+      );
 
       return {
         credentialKeyPair,

--- a/src/step/issuance/fetch-metadata-step.ts
+++ b/src/step/issuance/fetch-metadata-step.ts
@@ -6,7 +6,8 @@ import { StepFlow, StepResponse } from "../step-flow";
 
 export interface FetchMetadataExecuteResponse {
   discoveredVia?: "federation" | "oid4vci";
-  entityStatementClaims?: any;
+  // Entity statement metadata is version-dependent and consumed structurally by orchestrators/tests.
+  entityStatementClaims?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   status: number;
 }
 

--- a/src/step/issuance/fetch-metadata-step.ts
+++ b/src/step/issuance/fetch-metadata-step.ts
@@ -47,7 +47,10 @@ export class FetchMetadataDefaultStep extends StepFlow {
         credentialIssuerUrl: options.baseUrl,
       });
 
-      log.debug("Metadata fetched successfully:", JSON.stringify(result, null, 2));
+      log.debug(
+        "Metadata fetched successfully:",
+        JSON.stringify(result, null, 2),
+      );
 
       return {
         discoveredVia: result.discoveredVia,

--- a/src/step/issuance/pushed-authorization-request-step.ts
+++ b/src/step/issuance/pushed-authorization-request-step.ts
@@ -128,7 +128,10 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
           ...options.createParOverrides,
         };
 
-        log.debug("Final PAR options:", JSON.stringify(finalParOptions, null, 2));
+        log.debug(
+          "Final PAR options:",
+          JSON.stringify(finalParOptions, null, 2),
+        );
 
         log.info(
           `Sending PAR request to ${options.pushedAuthorizationRequestEndpoint}`,
@@ -156,7 +159,8 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
 
         log.debug(`PKCE code verifier ${codeVerifier}`);
 
-        const parResponse = await fetchPushedAuthorizationResponse(fetchOptions);
+        const parResponse =
+          await fetchPushedAuthorizationResponse(fetchOptions);
         log.debug("PAR response:", JSON.stringify(parResponse, null, 2));
 
         return {

--- a/src/step/issuance/token-request-step.ts
+++ b/src/step/issuance/token-request-step.ts
@@ -108,7 +108,10 @@ export class TokenRequestDefaultStep extends StepFlow {
         walletAttestation: options.walletAttestation.attestation,
       };
 
-      log.debug("Token request options:", JSON.stringify(fetchTokenResponseOptions, null, 2));
+      log.debug(
+        "Token request options:",
+        JSON.stringify(fetchTokenResponseOptions, null, 2),
+      );
 
       const tokenResponse = await fetchTokenResponse(fetchTokenResponseOptions);
 

--- a/src/step/presentation/authorization-request-step.ts
+++ b/src/step/presentation/authorization-request-step.ts
@@ -134,7 +134,10 @@ export class AuthorizationRequestDefaultStep extends StepFlow {
         },
         vp_token,
       });
-      log.debug("Authorization Response created:", JSON.stringify(authorizationResponse, null, 2));
+      log.debug(
+        "Authorization Response created:",
+        JSON.stringify(authorizationResponse, null, 2),
+      );
 
       return {
         authorizationRequestHeader: parsedAuthorizeRequest.header,

--- a/src/step/presentation/fetch-metadata-step.ts
+++ b/src/step/presentation/fetch-metadata-step.ts
@@ -7,7 +7,8 @@ import { fetchWithRetries } from "@/logic/utils";
 import { StepFlow, StepResponse } from "../step-flow";
 
 export interface FetchMetadataVpExecuteResponse {
-  entityStatementClaims?: any;
+  // Entity statement metadata is version-dependent and consumed structurally by orchestrators/tests.
+  entityStatementClaims?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   headers?: Headers;
   status: number;
 }

--- a/tests/conformance/issuance/credential-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/credential-validation.issuance.spec.ts
@@ -315,6 +315,7 @@ testConfigs.forEach((testConfig) => {
           "→ Validating issuer rejected the duplicate-key batch request...",
         );
 
+        let rejection: unknown;
         try {
           const response = await fetchCredentialResponse({
             accessToken: accessToken,
@@ -329,15 +330,16 @@ testConfigs.forEach((testConfig) => {
 
           testSuccess = false;
         } catch (error) {
+          rejection = error;
           log.debug(
             "  Request failed as expected with error: " +
               (error instanceof Error ? error.message : String(error)),
           );
-          expect(error).toBeInstanceOf(Error);
-          expect((error as Error).message).toMatch(/invalid_proof/i);
 
           testSuccess = true;
         }
+        expect(rejection).toBeInstanceOf(Error);
+        expect((rejection as Error).message).toMatch(/invalid_proof/i);
       } finally {
         log.testCompleted(DESCRIPTION, testSuccess);
       }
@@ -645,41 +647,54 @@ testConfigs.forEach((testConfig) => {
           log.debug(`  Status claim present: ${statusClaim !== undefined}`);
 
           const specVersion = ioWalletSdkConfig.itWalletSpecsVersion;
-          if (specVersion === ItWalletSpecsVersion.V1_3) {
-            expect(
-              statusClaim?.["status_list"],
-              "V1.3 MUST contain 'status_list'",
-            ).toBeDefined();
-            const sl = statusClaim?.["status_list"] as
-              | Record<string, unknown>
-              | undefined;
-            expect(
-              typeof sl?.["idx"],
-              "'status_list.idx' MUST be a number",
-            ).toBe("number");
-            expect(
-              typeof sl?.["uri"],
-              "'status_list.uri' MUST be a string",
-            ).toBe("string");
+          const statusList = statusClaim?.["status_list"] as
+            | Record<string, unknown>
+            | undefined;
+          const statusAssertion = statusClaim?.["status_assertion"] as
+            | Record<string, unknown>
+            | undefined;
+          const requiredStatusField =
+            specVersion === ItWalletSpecsVersion.V1_3
+              ? {
+                  message: "V1.3 MUST contain 'status_list'",
+                  value: statusList,
+                }
+              : {
+                  message: "V1.0 MUST contain 'status_assertion'",
+                  value: statusAssertion,
+                };
+          const statusTypeChecks =
+            specVersion === ItWalletSpecsVersion.V1_3
+              ? [
+                  {
+                    actual: typeof statusList?.["idx"],
+                    expected: "number",
+                    message: "'status_list.idx' MUST be a number",
+                  },
+                  {
+                    actual: typeof statusList?.["uri"],
+                    expected: "string",
+                    message: "'status_list.uri' MUST be a string",
+                  },
+                ]
+              : [
+                  {
+                    actual: typeof statusAssertion?.["credential_hash_alg"],
+                    expected: "string",
+                    message: "'credential_hash_alg' MUST be a string",
+                  },
+                ];
 
-            log.debug(
-              "  ✅ Credential contains a status claim referencing a status list",
-            );
-          } else {
-            expect(
-              statusClaim?.["status_assertion"],
-              "V1.0 MUST contain 'status_assertion'",
-            ).toBeDefined();
-            const sa = statusClaim?.["status_assertion"] as
-              | Record<string, unknown>
-              | undefined;
-            expect(
-              typeof sa?.["credential_hash_alg"],
-              "'credential_hash_alg' MUST be a string",
-            ).toBe("string");
-
-            log.debug("  ✅ Credential contains a status assertion");
+          expect(requiredStatusField.value).toBeDefined();
+          for (const check of statusTypeChecks) {
+            expect(check.actual).toBe(check.expected);
           }
+
+          log.debug(
+            specVersion === ItWalletSpecsVersion.V1_3
+              ? "  ✅ Credential contains a status claim referencing a status list"
+              : "  ✅ Credential contains a status assertion",
+          );
         }
 
         testSuccess = true;

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -570,12 +570,22 @@ testConfigs.forEach((testConfig) => {
 
         const claims = decodeJwt(token ?? "");
         const currentTime = Date.now() / 1e3;
+        const issuedAt = claims.iat;
+        const expiresAt = claims.exp;
 
-        log.debug(`  iat: ${new Date(claims.iat! * 1000).toISOString()}`);
-        log.debug(`  exp: ${new Date(claims.exp! * 1000).toISOString()}`);
+        expect(issuedAt).toEqual(expect.any(Number));
+        expect(expiresAt).toEqual(expect.any(Number));
+        if (typeof issuedAt !== "number" || typeof expiresAt !== "number") {
+          throw new Error(
+            "Access token must contain numeric iat and exp claims",
+          );
+        }
 
-        expect(claims.exp).toBeGreaterThan(currentTime);
-        expect(claims.iat).toBeLessThan(currentTime);
+        log.debug(`  iat: ${new Date(issuedAt * 1000).toISOString()}`);
+        log.debug(`  exp: ${new Date(expiresAt * 1000).toISOString()}`);
+
+        expect(expiresAt).toBeGreaterThan(currentTime);
+        expect(issuedAt).toBeLessThan(currentTime);
 
         testSuccess = true;
       } finally {
@@ -813,15 +823,19 @@ testConfigs.forEach((testConfig) => {
             "SD-JWT credential must contain cnf claim for key binding",
           ).toBeDefined();
 
-          if (payload?.cnf?.jwk) {
-            const credentialJkt = await calculateJwkThumbprint(payload.cnf.jwk);
-            log.debug(`  Credential JWK Thumbprint: ${credentialJkt}`);
-            expect(credentialJkt).toBe(expectedJkt);
-          } else {
-            expect.fail(
+          const confirmationJwk = payload?.cnf?.jwk;
+          expect(
+            confirmationJwk,
+            "SD-JWT credential cnf claim must contain either jkt or jwk",
+          ).toBeDefined();
+          if (!confirmationJwk) {
+            throw new Error(
               "SD-JWT credential cnf claim must contain either jkt or jwk",
             );
           }
+          const credentialJkt = await calculateJwkThumbprint(confirmationJwk);
+          log.debug(`  Credential JWK Thumbprint: ${credentialJkt}`);
+          expect(credentialJkt).toBe(expectedJkt);
         }
 
         testSuccess = true;
@@ -841,13 +855,14 @@ testConfigs.forEach((testConfig) => {
 
       let testSuccess = false;
       try {
+        let hasValidFormat = false;
         for (const credential of credentialResponse.response?.credentials ??
           []) {
           try {
             await SDJwt.extractJwt(credential.credential);
             log.debug("  Format: SD-JWT VC");
-            testSuccess = true;
-            return;
+            hasValidFormat = true;
+            break;
           } catch {
             log.debug("  Not SD-JWT, trying mdoc-CBOR...");
           }
@@ -855,14 +870,17 @@ testConfigs.forEach((testConfig) => {
           try {
             parseMdoc(Buffer.from(credential.credential));
             log.debug("  Format: mdoc-CBOR");
-            testSuccess = true;
-            return;
+            hasValidFormat = true;
+            break;
           } catch {
             log.error("  Credential is neither SD-JWT VC nor mdoc-CBOR format");
           }
         }
 
-        log.error("  No credentials found in valid format");
+        expect(hasValidFormat, "No credentials found in valid format").toBe(
+          true,
+        );
+        testSuccess = hasValidFormat;
       } finally {
         log.testCompleted(DESCRIPTION, testSuccess);
       }

--- a/tests/conformance/presentation/happy.presentation.spec.ts
+++ b/tests/conformance/presentation/happy.presentation.spec.ts
@@ -60,6 +60,10 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
 
       const entityClaims = fetchMetadataResult.response?.entityStatementClaims;
       const issuer = entityClaims?.sub;
+      expect(issuer).toBeDefined();
+      if (!issuer) {
+        throw new Error("Entity statement issuer is required");
+      }
 
       expect(authorizationRequestResult.success).toBe(true);
       expect(authorizationRequestResult.response).toBeDefined();
@@ -69,13 +73,11 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
       expect(parsedQrCode?.clientId).toBeDefined();
 
       // The client_id should match the issuer from the entity statement
-      if (issuer) {
-        log.debug(`  Expected: ${issuer}`);
-        log.debug(`  Actual: ${parsedQrCode?.clientId}`);
-        const rawClientId = parsedQrCode?.clientId ?? "";
-        expect(normalizeClientId(rawClientId)).toBe(issuer);
-        log.debug("  ✅ client_id matches entity statement issuer");
-      }
+      log.debug(`  Expected: ${issuer}`);
+      log.debug(`  Actual: ${parsedQrCode?.clientId}`);
+      const rawClientId = parsedQrCode?.clientId ?? "";
+      expect(normalizeClientId(rawClientId)).toBe(issuer);
+      log.debug("  ✅ client_id matches entity statement issuer");
 
       log.debug("→ Checking request_uri format and domain validity...");
       expect(parsedQrCode?.requestUri).toBeDefined();
@@ -111,13 +113,13 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
       expect(authorizationRequestResult.success).toBe(true);
       expect(authorizationRequestResult.response?.requestObject).toBeDefined();
 
+      const requestObjectEndpointMethods =
+        verifierMetadata?.request_object_endpoint_methods ?? ["GET"];
+
       // If request_object_endpoint_methods is not specified or includes GET
       if (verifierMetadata?.request_object_endpoint_methods) {
         log.debug(
           `  Supported methods: ${verifierMetadata.request_object_endpoint_methods.join(", ")}`,
-        );
-        expect(verifierMetadata.request_object_endpoint_methods).toContain(
-          "GET",
         );
         log.debug("  ✅ GET method is supported");
       } else {
@@ -125,6 +127,7 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
           "  ℹ request_object_endpoint_methods not specified (GET is default)",
         );
       }
+      expect(requestObjectEndpointMethods).toContain("GET");
 
       testSuccess = true;
     } finally {
@@ -275,33 +278,39 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
 
       expect(dcqlQuery?.credentials).toBeDefined();
 
-      // Check each credential in DCQL
-      let walletAttestationFound = false;
-      dcqlQuery?.credentials.forEach((credential: unknown, index: number) => {
-        if (
-          credential &&
-          typeof credential === "object" &&
-          "meta" in credential
-        ) {
+      const walletAttestationCredentials = (dcqlQuery?.credentials ?? [])
+        .map((credential: unknown, index: number) => ({
+          credential,
+          index,
+        }))
+        .filter(({ credential }: { credential: unknown; index: number }) => {
+          if (
+            !credential ||
+            typeof credential !== "object" ||
+            !("meta" in credential)
+          ) {
+            return false;
+          }
           const cred = credential as {
-            claims?: unknown[];
             meta?: { vct_values?: string[] };
           };
+          return cred.meta?.vct_values?.includes(
+            "urn:eu.europa.ec.eudi:wallet_attestation:1",
+          );
+        });
 
-          // Wallet Attestation credentials should not have claims parameter
-          if (
-            cred.meta?.vct_values?.includes(
-              "urn:eu.europa.ec.eudi:wallet_attestation:1",
-            )
-          ) {
-            walletAttestationFound = true;
-            log.debug(`  Credential ${index + 1}: Wallet Attestation detected`);
-            log.debug(`    vct: ${cred.meta?.vct_values?.join(", ")}`);
-            expect(cred.claims).toBeUndefined();
-            log.debug("    ✅ claims parameter is not present (as required)");
-          }
-        }
-      });
+      for (const { credential, index } of walletAttestationCredentials) {
+        const cred = credential as {
+          claims?: unknown[];
+          meta?: { vct_values?: string[] };
+        };
+        log.debug(`  Credential ${index + 1}: Wallet Attestation detected`);
+        log.debug(`    vct: ${cred.meta?.vct_values?.join(", ")}`);
+        expect(cred.claims).toBeUndefined();
+        log.debug("    ✅ claims parameter is not present (as required)");
+      }
+
+      const walletAttestationFound = walletAttestationCredentials.length > 0;
 
       if (walletAttestationFound) {
         log.debug("  ✅ Wallet Attestation validated successfully");
@@ -335,31 +344,39 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
 
       expect(dcqlQuery?.credentials).toBeDefined();
 
-      // Check that all credentials have meta.vct_values
-      let hasVctValues = false;
-      let credentialIndex = 0;
-      dcqlQuery?.credentials.forEach((credential: unknown) => {
-        credentialIndex++;
-        if (
-          credential &&
-          typeof credential === "object" &&
-          "meta" in credential
-        ) {
+      const credentialsWithVctValues = (dcqlQuery?.credentials ?? [])
+        .map((credential: unknown, index: number) => ({
+          credential,
+          index,
+        }))
+        .filter(({ credential }: { credential: unknown; index: number }) => {
+          if (
+            !credential ||
+            typeof credential !== "object" ||
+            !("meta" in credential)
+          ) {
+            return false;
+          }
           const cred = credential as {
             meta?: { vct_values?: string[] };
           };
-          if (cred.meta?.vct_values) {
-            hasVctValues = true;
-            log.debug(`  Credential ${credentialIndex}:`);
-            expect(Array.isArray(cred.meta.vct_values)).toBe(true);
-            log.debug(`    vct_values: ${cred.meta.vct_values.join(", ")}`);
-            expect(cred.meta.vct_values.length).toBeGreaterThan(0);
-            log.debug(
-              `    ✅ vct_values is valid (${cred.meta.vct_values.length} type(s))`,
-            );
-          }
-        }
-      });
+          return Boolean(cred.meta?.vct_values);
+        });
+
+      for (const { credential, index } of credentialsWithVctValues) {
+        const cred = credential as {
+          meta: { vct_values: string[] };
+        };
+        log.debug(`  Credential ${index + 1}:`);
+        expect(Array.isArray(cred.meta.vct_values)).toBe(true);
+        log.debug(`    vct_values: ${cred.meta.vct_values.join(", ")}`);
+        expect(cred.meta.vct_values.length).toBeGreaterThan(0);
+        log.debug(
+          `    ✅ vct_values is valid (${cred.meta.vct_values.length} type(s))`,
+        );
+      }
+
+      const hasVctValues = credentialsWithVctValues.length > 0;
 
       expect(hasVctValues).toBe(true);
       log.debug("  ✅ All credentials have valid vct_values");

--- a/tests/helpers/par-validation-helpers.ts
+++ b/tests/helpers/par-validation-helpers.ts
@@ -109,14 +109,17 @@ export async function buildTamperedPopJwt(
     signJwt: signJwtCallback([realUnitKey]),
   };
 
+  const publicJwk = Object.fromEntries(
+    Object.entries(realUnitKey).filter(
+      ([key]) => !["alg", "d", "dp", "dq", "p", "q", "qi"].includes(key),
+    ),
+  ) as Jwk;
+
   const signer: JwtSignerJwk = {
     alg: realUnitKey.alg ?? "ES256",
     kid: realUnitKey.kid,
     method: "jwk",
-    // Strip private key fields
-    publicJwk: (({ alg: _alg, d, dp, dq, p, q, qi, ...pub }) => pub)(
-      realUnitKey,
-    ) as Jwk,
+    publicJwk,
   };
 
   return createClientAttestationPopJwt({

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   loadConfigWithHierarchy,
@@ -6,12 +6,82 @@ import {
 } from "@/logic/config-loader";
 
 const DEFAULT_INI = "./config.example.ini";
+const envKeys = [
+  "CONFIG_ISSUANCE_CERTIFICATE_SUBJECT",
+  "CONFIG_MAX_RETRIES",
+  "CONFIG_PORT",
+  "CONFIG_SAVE_CREDENTIAL",
+  "CONFIG_STEPS_MAPPING",
+  "CONFIG_TIMEOUT",
+  "CONFIG_UNSAFE_TLS",
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+];
 
 describe("loadConfigWithHierarchy – user_agent", () => {
+  const originalEnv = Object.fromEntries(
+    envKeys.map((key) => [key, process.env[key]]),
+  );
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      Reflect.deleteProperty(process.env, key);
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key);
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
   it("should always set user_agent to CEN-TC-Wallet-CLI/<version> from package.json", () => {
     const config = loadConfigWithHierarchy({}, DEFAULT_INI);
     expect(config.network.user_agent).toBe(
       `CEN-TC-Wallet-CLI/${readPackageVersion()}`,
     );
+  });
+
+  it("should map issuance certificate subject from environment", () => {
+    process.env.CONFIG_ISSUANCE_CERTIFICATE_SUBJECT =
+      "CN=test-issuer.example, O=PagoPA";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.issuance.certificate_subject).toBe(
+      "CN=test-issuer.example, O=PagoPA",
+    );
+  });
+
+  it("should parse numeric and boolean environment overrides", () => {
+    process.env.CONFIG_TIMEOUT = "42";
+    process.env.CONFIG_MAX_RETRIES = "7";
+    process.env.CONFIG_PORT = "3101";
+    process.env.CONFIG_SAVE_CREDENTIAL = "true";
+    process.env.CONFIG_UNSAFE_TLS = "true";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.network.timeout).toBe(42);
+    expect(config.network.max_retries).toBe(7);
+    expect(config.trust_anchor.port).toBe(3101);
+    expect(config.issuance.save_credential).toBe(true);
+    expect(config.network.tls_reject_unauthorized).toBe(false);
+  });
+
+  it("should parse comma-separated step mappings from environment", () => {
+    process.env.CONFIG_STEPS_MAPPING =
+      "HappyFlowIssuance=tests/steps/issuance,HappyFlowPresentation=tests/steps/presentation";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.steps_mapping.mapping).toEqual({
+      HappyFlowIssuance: "tests/steps/issuance",
+      HappyFlowPresentation: "tests/steps/presentation",
+    });
   });
 });

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { IssuerSignedDocument } from "@auth0/mdl";
 import {
   addSecondsToDate,
@@ -55,6 +56,7 @@ describe("Load Mocked Credentials", async () => {
   );
 
   it("should load a mix of valid sd-jwt and mdoc credentials V1_0", async () => {
+    let validationErrorMessage: string | undefined;
     try {
       const credentials = await loadCredentials(
         credentialsDir,
@@ -72,13 +74,12 @@ describe("Load Mocked Credentials", async () => {
     } catch (e) {
       if (e instanceof ValidationError) {
         console.error("Schema validation failed");
-        expect
-          .soft(
-            e.message.replace(": ", ":\n\t").replace(/,([A-Za-z])/g, "\n\t$1"),
-          )
-          .toBeNull();
+        validationErrorMessage = e.message
+          .replace(": ", ":\n\t")
+          .replace(/,([A-Za-z])/g, "\n\t$1");
       } else throw e;
     }
+    expect.soft(validationErrorMessage).toBeUndefined();
   });
 
   it("should create a new certificate", async () => {
@@ -97,11 +98,11 @@ describe("Load Mocked Credentials", async () => {
   });
 
   it("should create a new certificate in case the current one is actually expired", async () => {
-    (rmSync(
+    rmSync(
       "tests/mocked-data/federation_trust_anchors/localhost/trust_anchor_cert",
       { force: true },
-    ),
-      vi.useFakeTimers());
+    );
+    vi.useFakeTimers();
     const baseDate = new Date(2000, 1, 1);
     //Default expiration for the certificates is an year, so in two years it will be surely expired
     const twoYearsLater = new Date(2002, 1, 1);
@@ -586,10 +587,15 @@ describe("Generate Mocked Credentials", () => {
     );
 
     const claimsFromDecoded = decoded.disclosures?.reduce(
-      (prev, disclosure) => ({
-        ...prev,
-        [disclosure.key!]: disclosure.value,
-      }),
+      (prev, disclosure) => {
+        if (!disclosure.key) {
+          throw new Error("Disclosure key is required");
+        }
+        return {
+          ...prev,
+          [disclosure.key]: disclosure.value,
+        };
+      },
       {},
     );
 
@@ -625,10 +631,15 @@ describe("Generate Mocked Credentials", () => {
     );
 
     const claimsFromDecoded = decoded.disclosures?.reduce(
-      (prev, disclosure) => ({
-        ...prev,
-        [disclosure.key!]: disclosure.value,
-      }),
+      (prev, disclosure) => {
+        if (!disclosure.key) {
+          throw new Error("Disclosure key is required");
+        }
+        return {
+          ...prev,
+          [disclosure.key]: disclosure.value,
+        };
+      },
       {},
     );
 
@@ -834,8 +845,11 @@ describe("createVpTokenMdoc", () => {
     const documents = decode(Buffer.from(result, "base64url")).documents;
     expect(documents).toBeDefined();
 
-    const document = documents[0]!;
+    const document = documents[0];
     expect(document).toBeDefined();
+    if (!document) {
+      throw new Error("Expected device response to contain one document");
+    }
     expect(document.docType).toBe(docType);
     expect(document.issuerSigned.nameSpaces).toBeDefined();
     expect(document.issuerSigned.nameSpaces).toHaveProperty(namespace);

--- a/tests/unit/step/presentation/authorization-request-step.unit.spec.ts
+++ b/tests/unit/step/presentation/authorization-request-step.unit.spec.ts
@@ -52,6 +52,14 @@ vi.mock("@/logic/jwt", async (importOriginal) => {
   };
 });
 
+function getCreateAuthorizationResponseOptions() {
+  const [firstCall] = vi.mocked(createAuthorizationResponse).mock.calls;
+  if (!firstCall) {
+    throw new Error("createAuthorizationResponse was not called");
+  }
+  return firstCall[0];
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -196,7 +204,7 @@ describe("AuthorizationRequestDefaultStep", () => {
       });
 
       expect(createAuthorizationResponse).toHaveBeenCalledOnce();
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
 
       // The array must be forwarded to rpJwks so the SDK can pick the first value
       expect(callArgs.rpJwks.encrypted_response_enc_values_supported).toEqual([
@@ -223,7 +231,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
 
       expect(callArgs.authorization_encrypted_response_enc).toBe(
         "A128CBC-HS256",
@@ -246,7 +254,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
 
       expect(callArgs.authorization_encrypted_response_enc).toBeUndefined();
     });
@@ -266,7 +274,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
 
       expect(callArgs.rpJwks.encrypted_response_enc_values_supported).toEqual([
         "A256GCM",
@@ -296,7 +304,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
       expect(callArgs.authorization_encrypted_response_alg).toBe(
         "ECDH-ES+A256KW",
       );
@@ -317,7 +325,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
       expect(callArgs.authorization_encrypted_response_alg).toBeUndefined();
     });
   });
@@ -468,7 +476,7 @@ describe("AuthorizationRequestDefaultStep", () => {
         walletAttestation: {} as never,
       });
 
-      const callArgs = vi.mocked(createAuthorizationResponse).mock.calls[0]![0];
+      const callArgs = getCreateAuthorizationResponseOptions();
       expect(callArgs.rpJwks.jwks).toEqual(
         (baseVerifierMetadata as unknown as { jwks: unknown }).jwks,
       );


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, focusing on configuration handling, code review automation, and type safety. The most significant changes include a major refactor of the CLI/environment config loader to improve maintainability, the addition of a new GitHub Actions workflow for code review, and several type and logic cleanups in credential and mdoc handling.

Resolves: WLEO-1232

**Configuration Handling Refactor:**

- Refactored `cliOptionsToConfig` and related logic in `src/logic/config-loader.ts` to modularize config section building, reduce duplication, and improve maintainability. Added helpers for reading environment variables and type-safe mapping of CLI options to config sections. [[1]](diffhunk://#diff-76bf197369664af044a578aa64cbf19b406b5e64bf5a2191e3ec999855f18fbbR36-R39) [[2]](diffhunk://#diff-76bf197369664af044a578aa64cbf19b406b5e64bf5a2191e3ec999855f18fbbL170-R287) [[3]](diffhunk://#diff-76bf197369664af044a578aa64cbf19b406b5e64bf5a2191e3ec999855f18fbbR323-R333) [[4]](diffhunk://#diff-76bf197369664af044a578aa64cbf19b406b5e64bf5a2191e3ec999855f18fbbL323-R404)

**CI/CD and Automation:**

- Added a new `.github/workflows/code-review.yml` workflow to automate code review checks (dependency install, lint, type check, build) on pushes to `main` and pull requests.
- Updated `package.json` scripts: improved `pre-commit` to include type checking, added a `prepare` script for Husky, and removed the test step from `code-review` to decouple build and test phases.

**Credential and Attestation Logic Improvements:**

- Improved type handling and assignment in `buildMockMdlMdoc_V1_0` and `buildMockMdlMdoc_V1_3` to avoid unsafe casting and directly assign payloads. [[1]](diffhunk://#diff-15d2c49cc684844864137a643c48cea58cf2b9a6c5871d8f619ea421f7e8408dL84-R86) [[2]](diffhunk://#diff-15d2c49cc684844864137a643c48cea58cf2b9a6c5871d8f619ea421f7e8408dL106-R107) [[3]](diffhunk://#diff-50974342e2ffb34e7cb93b967d53d41fc7e062e994b304d623485ea9395db3e8L93-R95)
- Unified the attestation options type in `load-attestation.ts` to use `WalletAttestationOptions` for both V1_0 and V1_3, simplifying the code and reducing duplication. [[1]](diffhunk://#diff-9741130c705978f99eee90bf31efabdb83155e2f090f5d973a3d6ddaf11e1e7aL3-L4) [[2]](diffhunk://#diff-9741130c705978f99eee90bf31efabdb83155e2f090f5d973a3d6ddaf11e1e7aL116-R114) [[3]](diffhunk://#diff-9741130c705978f99eee90bf31efabdb83155e2f090f5d973a3d6ddaf11e1e7aL125-R123)

**Type Safety and Robustness:**

- Improved type safety and error handling in `parseCredentialStatus` and `privateKeyToPem`, including explicit case blocks and error handling for empty private keys. [[1]](diffhunk://#diff-829f463eca4cc0bddf83005cb71d5edaad668b3fbe47b84ec70684a6570de165L154-R163) [[2]](diffhunk://#diff-829f463eca4cc0bddf83005cb71d5edaad668b3fbe47b84ec70684a6570de165R181) [[3]](diffhunk://#diff-a7dbc77bfff91596eff350818e3d6c58540a5ad31206bba02215f8be7fd9868cL260-R264)
- Added a `DcqlMdocClaim` interface and improved type usage in mdoc claim conversion logic. [[1]](diffhunk://#diff-6de1e3a53fa96b6f11f2cd7a71001ab9f1f193cb26fe3742eb240002cc09ccb6R18-R23) [[2]](diffhunk://#diff-6de1e3a53fa96b6f11f2cd7a71001ab9f1f193cb26fe3742eb240002cc09ccb6R143-R154)

**Logging Improvements:**

- Improved debug logging formatting in `authorize-step.ts` for better readability in logs. [[1]](diffhunk://#diff-c25dc769f522728bbf24e943aafadb439a019132662e59231a790093ebf1509dL105-R108) [[2]](diffhunk://#diff-c25dc769f522728bbf24e943aafadb439a019132662e59231a790093ebf1509dL174-R180)