### PR TITLE
Fix npx package execution and config resolution

### DIFF
--- a/src/functions/V1_0/mock-credentials.ts
+++ b/src/functions/V1_0/mock-credentials.ts
@@ -2,7 +2,7 @@ import { DataItem, Document } from "@auth0/mdl";
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { digest, ES256, generateSalt } from "@sd-jwt/crypto-nodejs";
 import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-import { decode, encode, Tagged } from "cbor";
+import cbor from "cbor";
 import { decodeJwt } from "jose";
 
 import {
@@ -13,6 +13,8 @@ import {
 import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
+
+const { decode, encode, Tagged } = cbor;
 
 export async function buildIssuerEntityConfiguration_V1_0(
   metadata: {
@@ -85,7 +87,7 @@ export async function buildMockMdlMdoc_V1_0(
     payload: payloadWithStatus,
   });
 
-  const nameSpaces = new Map<string, Tagged[]>();
+  const nameSpaces = new Map<string, InstanceType<typeof Tagged>[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<
     string,
     DataItem[]

--- a/src/functions/V1_3/mock-credentials.ts
+++ b/src/functions/V1_3/mock-credentials.ts
@@ -2,7 +2,7 @@ import { DataItem, Document } from "@auth0/mdl";
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { digest, ES256, generateSalt } from "@sd-jwt/crypto-nodejs";
 import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-import { decode, encode, Tagged } from "cbor";
+import cbor from "cbor";
 import { decodeJwt } from "jose";
 
 import {
@@ -14,6 +14,8 @@ import {
 import { generateSRIHash } from "@/logic/sd-jwt";
 import { resolveTrustAnchorBaseUrl } from "@/trust-anchor/trust-anchor-resolver";
 import { Config, Credential, KeyPair, KeyPairJwk } from "@/types";
+
+const { decode, encode, Tagged } = cbor;
 
 export async function buildIssuerEntityConfiguration_V1_3(
   metadata: {
@@ -94,7 +96,7 @@ export async function buildMockMdlMdoc_V1_3(
     payload: payloadWithStatus,
   });
 
-  const nameSpaces = new Map<string, Tagged[]>();
+  const nameSpaces = new Map<string, InstanceType<typeof Tagged>[]>();
   for (const [namespace, items] of issuerSigned["nameSpaces"] as Map<
     string,
     DataItem[]

--- a/src/functions/load-credentials.ts
+++ b/src/functions/load-credentials.ts
@@ -1,7 +1,7 @@
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { SDJwt } from "@sd-jwt/core";
 import { digest } from "@sd-jwt/crypto-nodejs";
-import { decode } from "cbor";
+import cbor from "cbor";
 import { readdirSync, readFileSync } from "node:fs";
 
 import { buildJwksPath, ensureDir, loadJwks, parseMdoc } from "@/logic";
@@ -20,6 +20,8 @@ import {
   isCredentialMdocExpired,
   isCredentialSdJwtExpired,
 } from "./mock-credentials";
+
+const { decode } = cbor;
 
 /**
  * Loads credentials from a specified directory, verifies them, and returns the valid ones.

--- a/src/functions/mock-credentials.ts
+++ b/src/functions/mock-credentials.ts
@@ -1,7 +1,7 @@
 import { IssuerSignedDocument } from "@auth0/mdl";
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { SDJwt } from "@sd-jwt/core";
-import { Tagged } from "cbor";
+import cbor from "cbor";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import z from "zod";
 
@@ -33,6 +33,8 @@ import {
   buildMockMdlMdoc_V1_3,
   buildMockSdJwt_V1_3,
 } from "./V1_3/mock-credentials";
+
+const { Tagged } = cbor;
 
 export async function createMockMdlMdoc(
   subject: string,

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -10,6 +10,7 @@ import {
   readPackageVersion as readRuntimePackageVersion,
   resolveConfigRelativePath,
   resolveDefaultConfigPath,
+  resolveLocalConfigPath,
   resolvePathFrom,
   resolveWorkspacePath,
 } from "./runtime-paths";
@@ -113,7 +114,8 @@ export function loadConfigWithHierarchy(
       );
     }
   } else {
-    customLayer = loadConfigLayer(resolveWorkspacePath("config.ini"));
+    const localConfigPath = resolveLocalConfigPath();
+    customLayer = localConfigPath ? loadConfigLayer(localConfigPath) : null;
   }
 
   // Step 3: Convert CLI options to config format (highest priority)

--- a/src/logic/mdoc.ts
+++ b/src/logic/mdoc.ts
@@ -4,16 +4,18 @@ import {
   MDLParseError,
   MDoc,
 } from "@auth0/mdl";
-import IssuerAuth from "@auth0/mdl/lib/mdoc/model/IssuerAuth";
-import { PresentationDefinition } from "@auth0/mdl/lib/mdoc/model/PresentationDefinition";
+import IssuerAuth from "@auth0/mdl/lib/mdoc/model/IssuerAuth.js";
+import { PresentationDefinition } from "@auth0/mdl/lib/mdoc/model/PresentationDefinition.js";
 import {
   parseWithErrorHandling,
   ValidationError,
 } from "@pagopa/io-wallet-utils";
-import { decode } from "cbor";
+import cbor from "cbor";
 import { DcqlQuery } from "dcql";
 
 import { issuerSignedSchema, VpTokenOptions } from "@/types";
+
+const { decode } = cbor;
 
 interface DcqlMdocClaim {
   claim_name?: string;

--- a/src/logic/mdoc.ts
+++ b/src/logic/mdoc.ts
@@ -1,10 +1,12 @@
+import type IssuerAuthClass from "@auth0/mdl/lib/mdoc/model/IssuerAuth.js";
+
 import {
   DeviceResponse,
   IssuerSignedDocument,
   MDLParseError,
   MDoc,
 } from "@auth0/mdl";
-import IssuerAuth from "@auth0/mdl/lib/mdoc/model/IssuerAuth.js";
+import * as issuerAuthModule from "@auth0/mdl/lib/mdoc/model/IssuerAuth.js";
 import { PresentationDefinition } from "@auth0/mdl/lib/mdoc/model/PresentationDefinition.js";
 import {
   parseWithErrorHandling,
@@ -16,6 +18,15 @@ import { DcqlQuery } from "dcql";
 import { issuerSignedSchema, VpTokenOptions } from "@/types";
 
 const { decode } = cbor;
+
+type IssuerAuthConstructor = typeof IssuerAuthClass;
+interface IssuerAuthModule {
+  default: IssuerAuthConstructor | { default: IssuerAuthConstructor };
+}
+
+const IssuerAuth = resolveIssuerAuthConstructor(
+  issuerAuthModule as unknown as IssuerAuthModule,
+);
 
 interface DcqlMdocClaim {
   claim_name?: string;
@@ -176,4 +187,23 @@ function convertDcqlToPresentationDefinition(
       },
     ],
   };
+}
+
+function resolveIssuerAuthConstructor(
+  module: IssuerAuthModule,
+): IssuerAuthConstructor {
+  if (typeof module.default === "function") {
+    return module.default;
+  }
+
+  if (
+    typeof module.default === "object" &&
+    module.default !== null &&
+    "default" in module.default &&
+    typeof module.default.default === "function"
+  ) {
+    return module.default.default;
+  }
+
+  throw new TypeError("Unable to load IssuerAuth constructor");
 }

--- a/src/logic/runtime-paths.ts
+++ b/src/logic/runtime-paths.ts
@@ -54,6 +54,23 @@ export function resolveDefaultConfigPath(): string {
   return path.join(packageRoot, "config.example.ini");
 }
 
+export function resolveLocalConfigPath(
+  workspaceDir = process.cwd(),
+  rootDir = packageRoot,
+): null | string {
+  const workspaceConfigPath = path.resolve(workspaceDir, "config.ini");
+  if (existsSync(workspaceConfigPath)) {
+    return workspaceConfigPath;
+  }
+
+  const packageConfigPath = path.join(rootDir, "config.ini");
+  if (existsSync(packageConfigPath)) {
+    return packageConfigPath;
+  }
+
+  return null;
+}
+
 export function resolvePackageAssetPath(relativePath: string): string {
   if (path.isAbsolute(relativePath)) {
     return relativePath;

--- a/src/types/mdoc.ts
+++ b/src/types/mdoc.ts
@@ -1,5 +1,7 @@
-import { Tagged } from "cbor";
+import cbor from "cbor";
 import z from "zod";
+
+const { Tagged } = cbor;
 
 /**
  * Defines the Zod schema for validating the structure of an issuer-signed document within an mdoc.

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -867,7 +867,7 @@ testConfigs.forEach((testConfig) => {
           }
 
           try {
-            parseMdoc(Buffer.from(credential.credential));
+            parseMdoc(Buffer.from(credential.credential, "base64url"));
             log.debug("  Format: mdoc-CBOR");
             hasValidFormat = true;
             break;

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -7,7 +7,7 @@ import {
   loadConfigWithHierarchy,
   readPackageVersion,
 } from "@/logic/config-loader";
-import { packageRoot } from "@/logic/runtime-paths";
+import { packageRoot, resolveLocalConfigPath } from "@/logic/runtime-paths";
 
 const DEFAULT_INI = path.join(packageRoot, "config.example.ini");
 const envKeys = [
@@ -148,6 +148,37 @@ describe("loadConfigWithHierarchy – path resolution", () => {
       path.join(process.cwd(), "local/logs/test.log"),
     );
     expect(config.issuance.url).toBe("https://local-issuer.example");
+  });
+
+  it("should resolve package config.ini when launch directory has none", () => {
+    const launchDir = mkdtempSync(path.join(tmpdir(), "wct-launch-"));
+    const packageDir = mkdtempSync(path.join(tmpdir(), "wct-package-"));
+    tempDirs.push(launchDir, packageDir);
+    const packageConfigPath = path.join(packageDir, "config.ini");
+    writeFileSync(
+      packageConfigPath,
+      "[issuance]\nurl = https://issuer.example",
+    );
+
+    expect(resolveLocalConfigPath(launchDir, packageDir)).toBe(
+      packageConfigPath,
+    );
+  });
+
+  it("should prefer launch directory config.ini over package config.ini", () => {
+    const launchDir = mkdtempSync(path.join(tmpdir(), "wct-launch-"));
+    const packageDir = mkdtempSync(path.join(tmpdir(), "wct-package-"));
+    tempDirs.push(launchDir, packageDir);
+    const launchConfigPath = path.join(launchDir, "config.ini");
+    writeFileSync(launchConfigPath, "[issuance]\nurl = https://launch.example");
+    writeFileSync(
+      path.join(packageDir, "config.ini"),
+      "[issuance]\nurl = https://package.example",
+    );
+
+    expect(resolveLocalConfigPath(launchDir, packageDir)).toBe(
+      launchConfigPath,
+    );
   });
 
   it("should merge partial runtime sections without requiring path fields", () => {

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -10,7 +10,7 @@ import { X509Certificate } from "@peculiar/x509";
 import { digest } from "@sd-jwt/crypto-nodejs";
 import { decodeJwt } from "@sd-jwt/decode";
 import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-import { decode } from "cbor";
+import cbor from "cbor";
 import { DcqlQuery } from "dcql";
 import { rmSync } from "node:fs";
 import { afterAll, describe, expect, it, vi } from "vitest";
@@ -43,6 +43,7 @@ import { KeyPairJwk, zTrustChain, zX5c } from "@/types";
 const backupDir = "./tests/mocked-data/backup";
 const credentialsDir = "./tests/mocked-data/credentials";
 const iss = "https://issuer.example.com";
+const { decode } = cbor;
 
 describe("Load Mocked Credentials", async () => {
   const config = loadConfig("./config.ini");

--- a/tests/unit/vitest-common.unit.spec.ts
+++ b/tests/unit/vitest-common.unit.spec.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildExcludePatterns,
   buildIncludePattern,
   createTestConfig,
   resolveConfigPath,
@@ -54,6 +55,20 @@ describe("buildIncludePattern", () => {
 
     expect(includePattern).toBe(
       "D:/custom/presentation-tests/**/*.presentation.spec.{js,ts}",
+    );
+  });
+});
+
+describe("buildExcludePatterns", () => {
+  it("allows bundled package tests to run from an installed node_modules path", () => {
+    expect(buildExcludePatterns(true)).not.toEqual(
+      expect.arrayContaining(["**/dist/**", "**/node_modules/**"]),
+    );
+  });
+
+  it("keeps default Vitest exclusions when running source tests", () => {
+    expect(buildExcludePatterns(false)).toEqual(
+      expect.arrayContaining(["**/dist/**", "**/node_modules/**"]),
     );
   });
 });

--- a/tests/unit/vitest-common.unit.spec.ts
+++ b/tests/unit/vitest-common.unit.spec.ts
@@ -1,6 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { buildIncludePattern } from "../../vitest.common.js";
+import {
+  buildIncludePattern,
+  createTestConfig,
+  resolveConfigPath,
+} from "../../vitest.common.js";
+
+const packageRoot = path.resolve(import.meta.dirname, "../..");
+
+function withTempPackageDirs(
+  run: (dirs: { launchDir: string; packageDir: string }) => void,
+) {
+  const launchDir = mkdtempSync(path.join(tmpdir(), "wct-launch-"));
+  const packageDir = mkdtempSync(path.join(tmpdir(), "wct-package-"));
+  const originalConfigFileIni = process.env.CONFIG_FILE_INI;
+
+  try {
+    Reflect.deleteProperty(process.env, "CONFIG_FILE_INI");
+    run({ launchDir, packageDir });
+  } finally {
+    if (originalConfigFileIni === undefined) {
+      Reflect.deleteProperty(process.env, "CONFIG_FILE_INI");
+    } else {
+      process.env.CONFIG_FILE_INI = originalConfigFileIni;
+    }
+    rmSync(launchDir, { force: true, recursive: true });
+    rmSync(packageDir, { force: true, recursive: true });
+  }
+}
 
 describe("buildIncludePattern", () => {
   it("normalizes Windows paths before building the Vitest glob", () => {
@@ -25,5 +55,49 @@ describe("buildIncludePattern", () => {
     expect(includePattern).toBe(
       "D:/custom/presentation-tests/**/*.presentation.spec.{js,ts}",
     );
+  });
+});
+
+describe("resolveConfigPath", () => {
+  it("falls back to package config.ini before config.example.ini", () => {
+    withTempPackageDirs(({ launchDir, packageDir }) => {
+      const packageConfigPath = path.join(packageDir, "config.ini");
+      writeFileSync(
+        packageConfigPath,
+        "[issuance]\nurl = https://package.example",
+      );
+
+      expect(resolveConfigPath(launchDir, packageDir)).toBe(packageConfigPath);
+    });
+  });
+
+  it("prefers launch directory config.ini over package config.ini", () => {
+    withTempPackageDirs(({ launchDir, packageDir }) => {
+      const launchConfigPath = path.join(launchDir, "config.ini");
+      writeFileSync(
+        launchConfigPath,
+        "[issuance]\nurl = https://launch.example",
+      );
+      writeFileSync(
+        path.join(packageDir, "config.ini"),
+        "[issuance]\nurl = https://package.example",
+      );
+
+      expect(resolveConfigPath(launchDir, packageDir)).toBe(launchConfigPath);
+    });
+  });
+});
+
+describe("createTestConfig", () => {
+  it("anchors Vitest root and setup files to the package root", () => {
+    const config = createTestConfig("issuance");
+
+    expect(config.root).toBe(packageRoot);
+    expect(config.test?.globalSetup).toBe(
+      path.join(packageRoot, "tests/global-setup.ts"),
+    );
+    expect(config.test?.setupFiles).toEqual([
+      path.join(packageRoot, "tests/setup-tls.ts"),
+    ]);
   });
 });

--- a/vitest.common.d.ts
+++ b/vitest.common.d.ts
@@ -4,6 +4,8 @@ export function buildIncludePattern(
   userConfigured: boolean,
 ): string;
 
+export function buildExcludePatterns(runsBuiltTests: boolean): string[];
+
 export function createTestConfig(
   testType: string,
 ): import("vitest/config").UserConfig;

--- a/vitest.common.d.ts
+++ b/vitest.common.d.ts
@@ -7,3 +7,5 @@ export function buildIncludePattern(
 export function createTestConfig(
   testType: string,
 ): import("vitest/config").UserConfig;
+
+export function resolveConfigPath(launchDir?: string, rootDir?: string): string;

--- a/vitest.common.js
+++ b/vitest.common.js
@@ -17,6 +17,8 @@ const sourceTestsRoot = path.join(packageRoot, "tests");
 const builtTestsRoot = path.join(packageRoot, "dist/tests");
 const useBuiltTests =
   !fs.existsSync(sourceTestsRoot) && fs.existsSync(builtTestsRoot);
+const testsRoot = useBuiltTests ? builtTestsRoot : sourceTestsRoot;
+const testFileExtension = useBuiltTests ? "js" : "ts";
 
 const log = createConsola({ level: 3 });
 
@@ -60,22 +62,40 @@ export function createTestConfig(testType) {
           : path.join(packageRoot, "src"),
       },
     },
+    root: packageRoot,
     test: {
       exclude,
       fileParallelism: false,
-      globalSetup: useBuiltTests
-        ? path.join(packageRoot, "dist/tests/global-setup.js")
-        : "./tests/global-setup.ts",
+      globalSetup: path.join(testsRoot, `global-setup.${testFileExtension}`),
       hookTimeout: 120000,
       include: [includePattern],
       reporters: ["dot"],
-      setupFiles: [
-        useBuiltTests
-          ? path.join(packageRoot, "dist/tests/setup-tls.js")
-          : "./tests/setup-tls.ts",
-      ],
+      setupFiles: [path.join(testsRoot, `setup-tls.${testFileExtension}`)],
     },
   });
+}
+
+export function resolveConfigPath(
+  launchDir = process.cwd(),
+  rootDir = packageRoot,
+) {
+  if (process.env.CONFIG_FILE_INI) {
+    return path.isAbsolute(process.env.CONFIG_FILE_INI)
+      ? process.env.CONFIG_FILE_INI
+      : path.resolve(launchDir, process.env.CONFIG_FILE_INI);
+  }
+
+  const localConfigPath = path.resolve(launchDir, "config.ini");
+  if (fs.existsSync(localConfigPath)) {
+    return localConfigPath;
+  }
+
+  const packageConfigPath = path.join(rootDir, "config.ini");
+  if (fs.existsSync(packageConfigPath)) {
+    return packageConfigPath;
+  }
+
+  return path.join(rootDir, "config.example.ini");
 }
 
 /**
@@ -132,19 +152,4 @@ function getTestsDir(testType) {
     );
     return { testsDir: defaultDirMap[testType], userConfigured: false };
   }
-}
-
-function resolveConfigPath() {
-  if (process.env.CONFIG_FILE_INI) {
-    return path.isAbsolute(process.env.CONFIG_FILE_INI)
-      ? process.env.CONFIG_FILE_INI
-      : path.resolve(process.cwd(), process.env.CONFIG_FILE_INI);
-  }
-
-  const localConfigPath = path.resolve(process.cwd(), "config.ini");
-  if (fs.existsSync(localConfigPath)) {
-    return localConfigPath;
-  }
-
-  return path.join(packageRoot, "config.example.ini");
 }

--- a/vitest.common.js
+++ b/vitest.common.js
@@ -22,9 +22,15 @@ const testFileExtension = useBuiltTests ? "js" : "ts";
 
 const log = createConsola({ level: 3 });
 
-const exclude = useBuiltTests
-  ? configDefaults.exclude.filter((pattern) => pattern !== "**/dist/**")
-  : configDefaults.exclude;
+const exclude = buildExcludePatterns(useBuiltTests);
+
+export function buildExcludePatterns(runsBuiltTests) {
+  return runsBuiltTests
+    ? configDefaults.exclude.filter(
+        (pattern) => !["**/dist/**", "**/node_modules/**"].includes(pattern),
+      )
+    : configDefaults.exclude;
+}
 
 export function buildIncludePattern(testType, testsDir, userConfigured) {
   const normalizedTestsDir = testsDir.replace(/\\/g, "/");


### PR DESCRIPTION
## Summary
- Anchor Vitest issuance/presentation config to the package root so setup files resolve correctly when `wct` is launched from another directory.
- Resolve implicit `config.ini` in the expected order: explicit `--file-ini` / `CONFIG_FILE_INI`, launch directory, package root, then `config.example.ini`.
- Allow bundled `dist/tests` to be discovered when the package is installed under npm `_npx/.../node_modules`.
- Fix packaged ESM runtime compatibility for `@auth0/mdl` deep imports and CommonJS `cbor` imports.
- Add regression coverage for config path resolution, packaged-test exclusion rules, and affected credential helpers.

## Verification
- `pnpm vitest run tests/unit/vitest-common.unit.spec.ts`
- `pnpm vitest run tests/unit/config-loader.unit.spec.ts`
- `pnpm vitest run tests/unit/vitest-common.unit.spec.ts tests/unit/credentials.unit.spec.ts`
- `pnpm types:check`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm build`
- `npm pack --pack-destination /private/tmp/wct-npx-sim`
- `npm exec --yes --package /private/tmp/wct-npx-sim/pagopa-wallet-conformance-tool-1.1.5.tgz -- wct --version`
- `npm exec --yes --package /private/tmp/wct-npx-sim/pagopa-wallet-conformance-tool-1.1.5.tgz -- wct test:issuance --credential-issuer-uri https://io-d-itn-wallet-issuer-func-01.azurewebsites.net`

Related Jira: WLEO-1256