### PR TITLE
feat(config): add issuance_pid config and PID issuance guardrails (REQ-01)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ config.ini
 # Filenames are KSUID-based (collision-resistant) and must never be committed
 *.cert.pem
 *.key.pem
+
+.pnpm-store

--- a/config.example.ini
+++ b/config.example.ini
@@ -48,6 +48,17 @@ credential_types[] = dc_sd_jwt_EuropeanDisabilityCard
 # The credential_issuer field in the response will override the issuance url. 
 # credential_offer_uri=https://offer.example
 
+# Optional: PID Provider issuance simulation (see config.pid-provider.ini for a full template)
+# [issuance_pid]
+# mode = none
+# Admissible values: none | l2plus | l3
+# When mode != none, set identity fields (given_name, family_name, tax_id_code, birthdate, place_of_birth).
+# For l2plus also set mrz (TD-1) and personal_administrative_number (NUN).
+# mock_mrtd_enabled = false
+# Optional contact details for CI_053:
+# email = mario.rossi@example.it
+# phone_number = +390612345678
+
 [presentation]
 # Optional: override the directory where presentation test specs are discovered
 # tests_dir = ./tests/conformance/presentation

--- a/config.pid-provider.ini
+++ b/config.pid-provider.ini
@@ -1,0 +1,28 @@
+# PID Provider conformance profile — copy or merge into config.ini
+# Usage: wct test:issuance --file-ini config.pid-provider.ini
+
+[issuance]
+url = https://pid-provider-test.example
+credential_types[] = dc_sd_jwt_PersonIdentificationData
+
+[issuance_pid]
+# CieID LoA High (L3) — CI_051 happy path (no MRTD PoP steps)
+mode = l3
+given_name = Mario
+family_name = Rossi
+tax_id_code = RSSMRA80A10H501Z
+birthdate = 1980-01-10
+place_of_birth = Roma
+nationalities[] = IT
+# mock_mrtd_enabled defaults to true when mode != none; set explicitly to override:
+# mock_mrtd_enabled = true
+
+# Optional — CI_053 (only assert when the SUT requests contact details)
+# email = mario.rossi@example.it
+# phone_number = +390612345678
+
+# --- L2+ MRTD PoP profile (uncomment and set mode = l2plus) ---
+# mode = l2plus
+# personal_administrative_number = XX00000XX
+# mrz = IDITARSSMRA80A10H501Z<<<<<<<<<<<<<<<
+# mock_mrtd_enabled = true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,6 +104,12 @@ function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   if (options.tests) {
     env.TESTS = options.tests;
   }
+  if (options.issuancePidMode) {
+    env.CONFIG_ISSUANCE_PID_MODE = options.issuancePidMode;
+  }
+  if (options.mockMrtdEnabled !== undefined) {
+    env.CONFIG_MOCK_MRTD_ENABLED = options.mockMrtdEnabled.toString();
+  }
 
   return env;
 }
@@ -169,6 +175,14 @@ function addCommonOptions(command: Command): Command {
     .option(
       "--issuance-certificate-subject <string>",
       "Override mock issuer's certificate subject (e.g. 'CN=test-issuer.com,OU=issuance,S=IT') (env: CONFIG_ISSUANCE_CERTIFICATE_SUBJECT)",
+    )
+    .option(
+      "--issuance-pid-mode <mode>",
+      "PID issuance mode: none | l2plus | l3 (env: CONFIG_ISSUANCE_PID_MODE)",
+    )
+    .option(
+      "--mock-mrtd-enabled",
+      "Enable mock eID/MRTD simulation (env: CONFIG_MOCK_MRTD_ENABLED=true). When omitted, derived from issuance_pid.mode.",
     )
     .option(
       "--presentation-tests-dir <path>",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -19,10 +19,34 @@ export class CredentialNamespaceNotFoundError extends Error {
   }
 }
 
+/** OpenID4VCI credential configuration id for Person Identification Data (PID). */
+export const PID_CREDENTIAL_CONFIGURATION_ID =
+  "dc_sd_jwt_PersonIdentificationData" as const;
+
 export class MissingFieldError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "MissingFieldError";
+  }
+}
+
+/**
+ * Thrown when `issuance.credential_types[]` requests PID issuance but
+ * `[issuance_pid].mode` is `none` (FR-3).
+ */
+export class PidIssuanceModeNotConfiguredError extends Error {
+  readonly code = "PID_ISSUANCE_MODE_NOT_CONFIGURED";
+  readonly credentialConfigurationId = PID_CREDENTIAL_CONFIGURATION_ID;
+
+  constructor() {
+    super(
+      `credential_types[] includes '${PID_CREDENTIAL_CONFIGURATION_ID}' but ` +
+        `[issuance_pid].mode is 'none'. ` +
+        `Fix: set [issuance_pid] mode = l3 or l2plus in config.ini, ` +
+        `or remove '${PID_CREDENTIAL_CONFIGURATION_ID}' from credential_types[] ` +
+        `for standard (Q)EAA issuance tests.`,
+    );
+    this.name = "PidIssuanceModeNotConfiguredError";
   }
 }
 export class StatusListTokenCreationError extends Error {

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -3,7 +3,12 @@ import { parse } from "ini";
 import { existsSync, readFileSync } from "node:fs";
 import path from "path";
 
+import { PidIssuanceModeNotConfiguredError } from "@/errors";
 import { Config, configSchema } from "@/types";
+import {
+  assertPidIssuanceCredentialGuard,
+  type PidIssuanceMode,
+} from "@/types/pid-issuance";
 
 import {
   packageRoot,
@@ -27,10 +32,12 @@ export interface CliOptions {
   credentialTypes?: string;
   fileIni?: string;
   issuanceCertificateSubject?: string;
+  issuancePidMode?: string;
   issuanceTestsDir?: string;
   logFile?: string;
   logLevel?: string;
   maxRetries?: number;
+  mockMrtdEnabled?: boolean;
   port?: number;
   presentationAuthorizeUri?: string;
   presentationTestsDir?: string;
@@ -152,8 +159,15 @@ export function loadConfigWithHierarchy(
   // Step 5: Validate the final configuration
   try {
     const validatedConfig = parseWithErrorHandling(configSchema, mergedConfig);
+    assertPidIssuanceCredentialGuard(
+      validatedConfig.issuance.credential_types,
+      validatedConfig.issuance_pid,
+    );
     return validatedConfig;
   } catch (e) {
+    if (e instanceof PidIssuanceModeNotConfiguredError) {
+      throw e;
+    }
     const err = e as Error;
     throw new Error(
       `Configuration validation failed: ${err.message}\n\n` +
@@ -193,6 +207,7 @@ export function readPackageVersion(): string {
 function cliOptionsToConfig(options: CliOptions): Partial<Config> {
   const partialConfig: Partial<Config> = {};
   const issuance = buildIssuanceConfig(options);
+  const issuancePid = buildIssuancePidConfig(options);
   const presentation = buildPresentationConfig(options);
   const network = buildNetworkConfig(options);
   const logging = buildLoggingConfig(options);
@@ -201,6 +216,9 @@ function cliOptionsToConfig(options: CliOptions): Partial<Config> {
 
   if (hasConfigValues<Config["issuance"]>(issuance)) {
     partialConfig.issuance = issuance as Config["issuance"];
+  }
+  if (hasConfigValues<Config["issuance_pid"]>(issuancePid)) {
+    partialConfig.issuance_pid = issuancePid as Config["issuance_pid"];
   }
   if (hasConfigValues<Config["presentation"]>(presentation)) {
     partialConfig.presentation = presentation as Config["presentation"];
@@ -326,6 +344,29 @@ function normalizeTestPaths<TConfig extends Partial<Config>>(
 
   return normalized;
 }
+
+const PID_ISSUANCE_MODES = ["none", "l2plus", "l3"] as const;
+
+function parsePidIssuanceMode(value: string): PidIssuanceMode | undefined {
+  return PID_ISSUANCE_MODES.includes(value as PidIssuanceMode)
+    ? (value as PidIssuanceMode)
+    : undefined;
+}
+
+const buildIssuancePidConfig: ConfigSectionBuilder<Config["issuance_pid"]> = (
+  options,
+) => {
+  const mode = options.issuancePidMode
+    ? parsePidIssuanceMode(options.issuancePidMode)
+    : undefined;
+
+  return {
+    ...(mode !== undefined && { mode }),
+    ...(options.mockMrtdEnabled !== undefined && {
+      mock_mrtd_enabled: options.mockMrtdEnabled,
+    }),
+  };
+};
 
 const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
   options,
@@ -484,6 +525,8 @@ function readCliOptionsFromEnv(): CliOptions {
     "CONFIG_PRESENTATION_AUTHORIZE_URI",
   );
   readStringEnv(options, "credentialTypes", "CONFIG_CREDENTIAL_TYPES");
+  readStringEnv(options, "issuancePidMode", "CONFIG_ISSUANCE_PID_MODE");
+  readBooleanEnv(options, "mockMrtdEnabled", "CONFIG_MOCK_MRTD_ENABLED");
   readNumberEnv(options, "timeout", "CONFIG_TIMEOUT");
   readNumberEnv(options, "maxRetries", "CONFIG_MAX_RETRIES");
   readStringEnv(options, "logLevel", "CONFIG_LOG_LEVEL");

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -41,10 +41,15 @@ import {
   AttestationResponse,
   Config,
   IssuanceFlowResponse,
+  PidIdentityConfig,
   RunThroughAuthorizeContext,
   RunThroughParContext,
   RunThroughTokenContext,
 } from "@/types";
+import {
+  isMockMrtdEnabledFromConfig,
+  pidIdentityConfigFromIssuancePid,
+} from "@/types/pid-issuance";
 
 export class WalletIssuanceOrchestratorFlow {
   private _authorizeResponse?: AuthorizeStepResponse;
@@ -63,8 +68,10 @@ export class WalletIssuanceOrchestratorFlow {
   private fetchMetadataStep: FetchMetadataDefaultStep;
   private issuanceConfig: IssuerTestConfiguration;
   private log = createLogger();
-
+  private readonly mockMrtdEnabled: boolean;
   private nonceRequestStep: NonceRequestDefaultStep;
+
+  private readonly pidIdentityConfig: PidIdentityConfig | undefined;
   private pushedAuthorizationRequestStep: PushedAuthorizationRequestDefaultStep;
   private tokenRequestStep: TokenRequestDefaultStep;
   private readonly TOTAL_STEPS = 6;
@@ -74,6 +81,10 @@ export class WalletIssuanceOrchestratorFlow {
     this.log = this.log.withTag(this.issuanceConfig.name);
 
     this.config = loadConfigWithHierarchy();
+    this.mockMrtdEnabled = isMockMrtdEnabledFromConfig(this.config);
+    this.pidIdentityConfig = pidIdentityConfigFromIssuancePid(
+      this.config.issuance_pid,
+    );
 
     this.log.setLogOptions({
       fileFormat: this.config.logging.log_file_format,
@@ -170,6 +181,14 @@ export class WalletIssuanceOrchestratorFlow {
 
   getLog(): typeof this.log {
     return this.log;
+  }
+
+  getMockMrtdEnabled(): boolean {
+    return this.mockMrtdEnabled;
+  }
+
+  getPidIdentityConfig(): PidIdentityConfig | undefined {
+    return this.pidIdentityConfig;
   }
 
   async issuance(): Promise<IssuanceFlowResponse> {
@@ -584,8 +603,10 @@ export class WalletIssuanceOrchestratorFlow {
       "Configuration Loaded:\n",
       JSON.stringify({
         credentialsDir: this.config.wallet.credentials_storage_path,
+        issuancePidMode: this.config.issuance_pid?.mode ?? "none",
         issuanceUrl: this.config.issuance.url,
         maxRetries: this.config.network.max_retries,
+        mockMrtdEnabled: this.mockMrtdEnabled,
         timeout: `${this.config.network.timeout}s`,
         userAgent: this.config.network.user_agent,
       }),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,7 @@
 import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import { z } from "zod";
 
+import { pidIssuanceSchema } from "./pid-issuance";
 import { parseItWalletSpecVersion } from "./version";
 
 /**
@@ -29,6 +30,7 @@ export const configSchema = z.object({
     tests_dir: z.string().default("./tests/issuance"),
     url: z.string().url(),
   }),
+  issuance_pid: pidIssuanceSchema.optional().default({ mode: "none" }),
   issuer: z.object({
     port: z.coerce.number(),
   }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,4 +7,5 @@ export * from "./issuance-orchestrator-context";
 export * from "./key-pair";
 export * from "./logger";
 export * from "./mdoc";
+export * from "./pid-issuance";
 export * from "./presentation-orchestrator-context";

--- a/src/types/pid-issuance.ts
+++ b/src/types/pid-issuance.ts
@@ -1,0 +1,249 @@
+import { z } from "zod";
+
+import {
+  PID_CREDENTIAL_CONFIGURATION_ID,
+  PidIssuanceModeNotConfiguredError,
+} from "@/errors";
+export { PID_CREDENTIAL_CONFIGURATION_ID };
+
+/**
+ * Accepts INI/env string values ("true"/"1"/"false"/"0") or real booleans.
+ * Mirrors {@link zBooleanFromString} in `config.ts` to avoid a circular import.
+ */
+const zBooleanFromString = z.union([z.boolean(), z.stringbool()]);
+
+/**
+ * Discriminator for the PID issuance flow, exposed via `[issuance_pid].mode`.
+ *
+ * - `none`   → standard (Q)EAA issuance flow; the `[issuance_pid]` section can
+ *              be omitted entirely. All existing tests must keep passing.
+ * - `l2plus` → SPID/CIEid substantial authentication with the full MRTD PoP
+ *              chain (init → validation JWT → verify → browser callback).
+ * - `l3`     → CIE+PIN high-LoA authentication, no MRTD PoP steps.
+ *
+ * The legacy `l2` mode (substantial without MRTD) is intentionally excluded
+ * from this iteration — see `B.1_progetto_di_modifica_per_implementazione`.
+ */
+export const pidIssuanceModeSchema = z.enum(["none", "l2plus", "l3"]);
+export type PidIssuanceMode = z.infer<typeof pidIssuanceModeSchema>;
+
+/**
+ * INI shape of the `[issuance_pid]` section, validated with Zod.
+ *
+ * Identity attributes are inline (no external file). `superRefine` enforces
+ * the conditional requirements coming from the B_1 functional spec:
+ *
+ *   - `mode != none`   → core identity fields (FR-4) are required
+ *   - `mode == l2plus` → MRTD-specific fields `mrz` and
+ *                        `personal_administrative_number` (NUN) are also
+ *                        required (FR-4 / FR-5)
+ *
+ * Format-level validation is intentionally permissive (non-empty strings,
+ * ISO-8601 date, RFC-compliant email) so that test fixtures don't break on
+ * regional variations of MRZ / NUN encodings. Stricter checks will be added
+ * by REQ-03 (`src/logic/pid-mrtd/`) when the data is actually consumed.
+ */
+export const pidIssuanceSchema = z
+  .object({
+    birthdate: z.iso.date().optional(),
+
+    email: z.email().optional(),
+    family_name: z.string().min(1).optional(),
+    given_name: z.string().min(1).optional(),
+    /**
+     * When set, overrides the derived flag `mode !== "none"` used by REQ-05
+     * orchestrator branching. Align with linee guida `MOCK_MRTD_ENABLED`.
+     */
+    mock_mrtd_enabled: zBooleanFromString.optional(),
+    mode: pidIssuanceModeSchema.default("none"),
+    mrz: z.string().min(1).optional(),
+    nationalities: z.array(z.string().min(1)).optional(),
+
+    personal_administrative_number: z.string().min(1).optional(),
+    phone_number: z.string().min(1).optional(),
+
+    place_of_birth: z.string().min(1).optional(),
+    tax_id_code: z.string().min(1).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.mode === "none") {
+      return;
+    }
+
+    const requiredIdentityFields = [
+      "given_name",
+      "family_name",
+      "tax_id_code",
+      "birthdate",
+      "place_of_birth",
+    ] as const;
+
+    for (const field of requiredIdentityFields) {
+      if (!data[field]) {
+        ctx.addIssue({
+          code: "custom",
+          message: `[issuance_pid] '${field}' is required when mode = '${data.mode}'`,
+          path: [field],
+        });
+      }
+    }
+
+    if (data.mode === "l2plus") {
+      if (!data.mrz) {
+        ctx.addIssue({
+          code: "custom",
+          message: "[issuance_pid] 'mrz' is required when mode = 'l2plus'",
+          path: ["mrz"],
+        });
+      }
+      if (!data.personal_administrative_number) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "[issuance_pid] 'personal_administrative_number' (NUN) is required when mode = 'l2plus'",
+          path: ["personal_administrative_number"],
+        });
+      }
+    }
+  });
+
+export type PidIssuanceConfig = z.infer<typeof pidIssuanceSchema>;
+
+/**
+ * FR-3: rejects PID in `credential_types[]` without a configured `[issuance_pid].mode`.
+ */
+export function assertPidIssuanceCredentialGuard(
+  credentialTypes: readonly string[],
+  issuancePid: PidIssuanceConfig,
+): void {
+  if (
+    configRequestsPidIssuance(credentialTypes) &&
+    issuancePid.mode === "none"
+  ) {
+    throw new PidIssuanceModeNotConfiguredError();
+  }
+}
+
+/**
+ * Returns true when the issuance test profile targets PID credentials.
+ */
+export function configRequestsPidIssuance(
+  credentialTypes: readonly string[],
+): boolean {
+  return credentialTypes.includes(PID_CREDENTIAL_CONFIGURATION_ID);
+}
+
+/**
+ * Static identity attributes sourced from `[issuance_pid]`, consumed by the
+ * mock IdP and the virtual CIE factory (`src/logic/pid-mrtd/`, REQ-03).
+ *
+ * Core fields are required once `mode` is `l2plus` or `l3` (enforced by
+ * `pidIssuanceSchema.superRefine`). `mrz` and `personal_administrative_number`
+ * are optional here because `l3` does not use MRTD; REQ-03 enforces them when
+ * building DG1/SOD for `l2plus`.
+ */
+export const pidIdentityConfigSchema = z.object({
+  birthdate: z.iso.date(),
+  email: z.email().optional(),
+  family_name: z.string().min(1),
+  given_name: z.string().min(1),
+  mrz: z.string().min(1).optional(),
+  nationalities: z.array(z.string().min(1)).optional(),
+  personal_administrative_number: z.string().min(1).optional(),
+  phone_number: z.string().min(1).optional(),
+  place_of_birth: z.string().min(1),
+  tax_id_code: z.string().min(1),
+});
+
+export type PidIdentityConfig = z.infer<typeof pidIdentityConfigSchema>;
+
+/**
+ * Runtime state for the L2+ MRTD PoP sub-flow (`mode = l2plus` only).
+ *
+ * Populated incrementally by `MockEidLoaInjectionAuth`, `MrtdPopRequest`,
+ * `MrtdPopValidation`, and `MrtdBrowserCallback` steps (REQ-04). Remains
+ * `undefined` for `mode = none` and `mode = l3` (FR-7).
+ *
+ * All fields are optional in REQ-01 so partial orchestrator runs can carry
+ * intermediate state; REQ-04 step tests will tighten required subsets per step.
+ */
+export const pidExtensionStateSchema = z.object({
+  challenge: z.string().min(1).optional(),
+  finalRedirectUri: z.string().min(1).optional(),
+  htm: z.string().min(1).optional(),
+  htuInit: z.string().min(1).optional(),
+  htuVerify: z.string().min(1).optional(),
+  mrtdAuthSession: z.string().min(1).optional(),
+  mrtdPopJwtNonce: z.string().min(1).optional(),
+  mrtdPopNonce: z.string().min(1).optional(),
+  mrtdProofJwt: z.string().min(1).optional(),
+  mrtdValPopNonce: z.string().min(1).optional(),
+  mrz: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+});
+
+export type PidExtensionState = z.infer<typeof pidExtensionStateSchema>;
+
+const PID_CORE_IDENTITY_FIELDS = [
+  "given_name",
+  "family_name",
+  "tax_id_code",
+  "birthdate",
+  "place_of_birth",
+] as const satisfies readonly (keyof PidIssuanceConfig)[];
+
+/**
+ * Projects validated `[issuance_pid]` config into {@link PidIdentityConfig}.
+ * Returns `undefined` when `mode = none` (no PID identity simulation active).
+ */
+/**
+ * Whether mock eID / MRTD simulation is active for this run.
+ *
+ * - Explicit `[issuance_pid].mock_mrtd_enabled` wins when present.
+ * - Otherwise `true` when `mode` is `l2plus` or `l3`.
+ */
+export function isMockMrtdEnabled(
+  issuancePid: PidIssuanceConfig | undefined,
+): boolean {
+  if (!issuancePid) {
+    return false;
+  }
+  if (issuancePid.mock_mrtd_enabled !== undefined) {
+    return issuancePid.mock_mrtd_enabled;
+  }
+  return issuancePid.mode !== "none";
+}
+
+/** Convenience wrapper over `config.issuance_pid`. */
+export function isMockMrtdEnabledFromConfig(config: {
+  issuance_pid?: PidIssuanceConfig;
+}): boolean {
+  return isMockMrtdEnabled(config.issuance_pid);
+}
+
+export function pidIdentityConfigFromIssuancePid(
+  issuancePid: PidIssuanceConfig | undefined,
+): PidIdentityConfig | undefined {
+  if (!issuancePid || issuancePid.mode === "none") {
+    return undefined;
+  }
+
+  for (const field of PID_CORE_IDENTITY_FIELDS) {
+    if (!issuancePid[field]) {
+      return undefined;
+    }
+  }
+
+  return pidIdentityConfigSchema.parse({
+    birthdate: issuancePid.birthdate,
+    email: issuancePid.email,
+    family_name: issuancePid.family_name,
+    given_name: issuancePid.given_name,
+    mrz: issuancePid.mrz,
+    nationalities: issuancePid.nationalities,
+    personal_administrative_number: issuancePid.personal_administrative_number,
+    phone_number: issuancePid.phone_number,
+    place_of_birth: issuancePid.place_of_birth,
+    tax_id_code: issuancePid.tax_id_code,
+  });
+}

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -14,6 +14,8 @@ const envKeys = [
   "CONFIG_FILE_INI",
   "CONFIG_ISSUANCE_TESTS_DIR",
   "CONFIG_ISSUANCE_CERTIFICATE_SUBJECT",
+  "CONFIG_ISSUANCE_PID_MODE",
+  "CONFIG_MOCK_MRTD_ENABLED",
   "CONFIG_LOG_FILE",
   "CONFIG_MAX_RETRIES",
   "CONFIG_PRESENTATION_TESTS_DIR",
@@ -67,6 +69,34 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
     expect(config.network.user_agent).toBe(
       `CEN-TC-Wallet-CLI/${readPackageVersion()}`,
     );
+  });
+
+  it("should map mock_mrtd_enabled from environment", () => {
+    process.env.CONFIG_MOCK_MRTD_ENABLED = "false";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.issuance_pid.mock_mrtd_enabled).toBe(false);
+  });
+
+  it("should map issuance_pid mode from environment", () => {
+    writeFileSync(
+      path.join(process.cwd(), "config.ini"),
+      [
+        "[issuance_pid]",
+        "mode = none",
+        "given_name = Mario",
+        "family_name = Rossi",
+        "tax_id_code = RSSMRA80A10H501Z",
+        "birthdate = 1980-01-10",
+        "place_of_birth = Roma",
+      ].join("\n"),
+    );
+    process.env.CONFIG_ISSUANCE_PID_MODE = "l3";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.issuance_pid.mode).toBe("l3");
   });
 
   it("should map issuance certificate subject from environment", () => {

--- a/tests/unit/issuance-pid-config.unit.spec.ts
+++ b/tests/unit/issuance-pid-config.unit.spec.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  PID_CREDENTIAL_CONFIGURATION_ID,
+  PidIssuanceModeNotConfiguredError,
+} from "@/errors";
+import { loadConfigWithHierarchy } from "@/logic/config-loader";
+import { packageRoot } from "@/logic/runtime-paths";
+import {
+  assertPidIssuanceCredentialGuard,
+  isMockMrtdEnabled,
+  pidIssuanceSchema,
+} from "@/types/pid-issuance";
+
+const DEFAULT_INI = path.join(packageRoot, "config.example.ini");
+
+const originalCwd = process.cwd();
+let tempDirs: string[] = [];
+
+function chdirTemp(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "wct-issuance-pid-config-"));
+  tempDirs.push(dir);
+  process.chdir(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  chdirTemp();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  tempDirs = [];
+});
+
+describe("assertPidIssuanceCredentialGuard (FR-3)", () => {
+  it("throws when PID is in credential_types and mode is none", () => {
+    expect(() =>
+      assertPidIssuanceCredentialGuard([PID_CREDENTIAL_CONFIGURATION_ID], {
+        mode: "none",
+      }),
+    ).toThrow(PidIssuanceModeNotConfiguredError);
+  });
+
+  it("allows PID credential_types when mode is l3", () => {
+    expect(() =>
+      assertPidIssuanceCredentialGuard([PID_CREDENTIAL_CONFIGURATION_ID], {
+        mode: "l3",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows QEA credential_types when mode is none", () => {
+    expect(() =>
+      assertPidIssuanceCredentialGuard(["dc_sd_jwt_EuropeanDisabilityCard"], {
+        mode: "none",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("isMockMrtdEnabled", () => {
+  it("returns false when mode is none and flag is unset", () => {
+    expect(isMockMrtdEnabled({ mode: "none" })).toBe(false);
+  });
+
+  it("returns true when mode is l3 and flag is unset", () => {
+    expect(isMockMrtdEnabled({ mode: "l3" })).toBe(true);
+  });
+
+  it("honours explicit mock_mrtd_enabled=false over mode l3", () => {
+    expect(isMockMrtdEnabled({ mock_mrtd_enabled: false, mode: "l3" })).toBe(
+      false,
+    );
+  });
+
+  it("honours explicit mock_mrtd_enabled=true over mode none", () => {
+    expect(isMockMrtdEnabled({ mock_mrtd_enabled: true, mode: "none" })).toBe(
+      true,
+    );
+  });
+});
+
+describe("pidIssuanceSchema", () => {
+  it("requires core identity fields when mode is l3", () => {
+    const result = pidIssuanceSchema.safeParse({ mode: "l3" });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(
+      result.error.issues.some((issue) => issue.path.includes("given_name")),
+    ).toBe(true);
+  });
+
+  it("requires mrz and NUN when mode is l2plus", () => {
+    const result = pidIssuanceSchema.safeParse({
+      birthdate: "1980-01-10",
+      family_name: "Rossi",
+      given_name: "Mario",
+      mode: "l2plus",
+      place_of_birth: "Roma",
+      tax_id_code: "RSSMRA80A10H501Z",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    const paths = result.error.issues.map((issue) => issue.path.join("."));
+    expect(paths).toContain("mrz");
+    expect(paths).toContain("personal_administrative_number");
+  });
+
+  it("accepts a complete l3 identity block", () => {
+    const result = pidIssuanceSchema.safeParse({
+      birthdate: "1980-01-10",
+      family_name: "Rossi",
+      given_name: "Mario",
+      mode: "l3",
+      place_of_birth: "Roma",
+      tax_id_code: "RSSMRA80A10H501Z",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("loadConfigWithHierarchy – issuance_pid FR-3", () => {
+  it("throws PidIssuanceModeNotConfiguredError for PID + mode none", () => {
+    writeFileSync(
+      path.join(process.cwd(), "config.ini"),
+      [
+        "[issuance]",
+        "url = https://pid-provider.example",
+        `credential_types[] = ${PID_CREDENTIAL_CONFIGURATION_ID}`,
+        "",
+        "[issuance_pid]",
+        "mode = none",
+      ].join("\n"),
+    );
+
+    expect(() => loadConfigWithHierarchy({}, DEFAULT_INI)).toThrow(
+      PidIssuanceModeNotConfiguredError,
+    );
+  });
+
+  it("loads when PID is requested with mode l3 and identity fields", () => {
+    writeFileSync(
+      path.join(process.cwd(), "config.ini"),
+      [
+        "[issuance]",
+        "url = https://pid-provider.example",
+        `credential_types[] = ${PID_CREDENTIAL_CONFIGURATION_ID}`,
+        "",
+        "[issuance_pid]",
+        "mode = l3",
+        "given_name = Mario",
+        "family_name = Rossi",
+        "tax_id_code = RSSMRA80A10H501Z",
+        "birthdate = 1980-01-10",
+        "place_of_birth = Roma",
+      ].join("\n"),
+    );
+
+    const config = loadConfigWithHierarchy({}, DEFAULT_INI);
+
+    expect(config.issuance_pid.mode).toBe("l3");
+    expect(config.issuance.credential_types).toContain(
+      PID_CREDENTIAL_CONFIGURATION_ID,
+    );
+  });
+
+  it("loads QEA profile with mode none (regression)", () => {
+    writeFileSync(
+      path.join(process.cwd(), "config.ini"),
+      [
+        "[issuance]",
+        "url = https://issuer.example",
+        "credential_types[] = dc_sd_jwt_EuropeanDisabilityCard",
+        "",
+        "[issuance_pid]",
+        "mode = none",
+      ].join("\n"),
+    );
+
+    const config = loadConfigWithHierarchy({}, DEFAULT_INI);
+
+    expect(config.issuance_pid.mode).toBe("none");
+    expect(config.issuance.credential_types).toEqual([
+      "dc_sd_jwt_EuropeanDisabilityCard",
+    ]);
+  });
+});


### PR DESCRIPTION
#### Motivation and Context

Implements **WCT-REQ-01** — the configuration foundation for simulating a **PID Provider** in the Wallet Conformance Tool (B.1 PID Provider extension).

Today the tool only supports standard (Q)EAA issuance via `[issuance]`. PID Provider conformance (CI_051, CI_053, L2+ MRTD flows) requires a dedicated `[issuance_pid]` section with identity attributes, issuance mode, and guardrails so misconfiguration fails early instead of at runtime.

This PR adds:

- **`[issuance_pid]` INI section** with `mode`: `none` | `l2plus` | `l3` (default `none` for full backward compatibility)
- **Zod validation** with conditional rules: identity fields when `mode != none`; `mrz` + `personal_administrative_number` when `mode = l2plus`
- **FR-3 guard**: if `credential_types[]` includes `dc_sd_jwt_PersonIdentificationData` while `mode` is `none`, config load fails with `PidIssuanceModeNotConfiguredError` and an actionable message
- **Types** `PidIdentityConfig`, `PidExtensionState`, and helpers (`pidIdentityConfigFromIssuancePid`, `isMockMrtdEnabledFromConfig`)
- **CLI/env overrides**: `--issuance-pid-mode`, `--mock-mrtd-enabled` (`CONFIG_ISSUANCE_PID_MODE`, `CONFIG_MOCK_MRTD_ENABLED`)
- **Templates**: commented `[issuance_pid]` in `config.example.ini`; new `config.pid-provider.ini` operational profile
- **Orchestrator wiring** (read-only for now): loads `pidIdentityConfig` and `mockMrtdEnabled` from config — actual MRTD/PID steps land in REQ-03+

No change to default QEA behaviour when `[issuance_pid]` is absent or `mode = none`.

**JIRA:** WCT-REQ-01

#### How Has This Been Tested?

- **Unit tests** (`pnpm test:unit`):
  - `tests/unit/issuance-pid-config.unit.spec.ts` — schema validation, FR-3 guard, `isMockMrtdEnabled`, config-loader integration with temp INI files
  - `tests/unit/config-loader.unit.spec.ts` — extended coverage for `issuance_pid` CLI/env mapping
- **Static checks**: `pnpm types:check`, `pnpm lint:check`, `pnpm format:check` (pre-commit)
- **Regression**: existing QEA profile (`mode = none`, no PID in `credential_types[]`) still loads successfully
- **Manual**: verified `config.pid-provider.ini` parses with `mode = l3` and PID credential type; confirmed FR-3 error message when PID is requested with `mode = none`

**Environment:** Node 24.x, pnpm 10.x, macOS

**Out of scope (follow-up PRs):** REQ-02 (PKI fixtures), REQ-03+ (MRTD steps, CIE factory, orchestrator branching).