### PR TITLE
Use conventional naming for RPR tests

### DIFF
--- a/tests/conformance/presentation/authorization-request.presentation.spec.ts
+++ b/tests/conformance/presentation/authorization-request.presentation.spec.ts
@@ -103,8 +103,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-25 — Malformed claims in presentation payload
   // -----------------------------------------------------------------------
 
-  test("RPR_025: Malformed claims in presentation payload | RP rejects a response whose decrypted payload contains malformed claims", async () => {
-    const log = baseLog.withTag("RPR_025");
+  test("RPR-25: Malformed claims in presentation payload | RP rejects a response whose decrypted payload contains malformed claims", async () => {
+    const log = baseLog.withTag("RPR-25");
     const DESCRIPTION = "RP correctly rejected response with malformed claims";
     log.start("Conformance test: Malformed claims in presentation payload");
 
@@ -151,8 +151,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-26 — Malformed claims in presented credentials
   // -----------------------------------------------------------------------
 
-  test("RPR_026: Malformed claims in presented credentials | RP rejects a response whose credential claims are malformed", async () => {
-    const log = baseLog.withTag("RPR_026");
+  test("RPR-26: Malformed claims in presented credentials | RP rejects a response whose credential claims are malformed", async () => {
+    const log = baseLog.withTag("RPR-26");
     const DESCRIPTION =
       "RP correctly rejected response with malformed credential claims";
     log.start("Conformance test: Malformed claims in presented credentials");
@@ -202,8 +202,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-37 — Response encryption failures
   // -----------------------------------------------------------------------
 
-  test("RPR_037: Response encryption failures | RP rejects a response encrypted with a wrong key", async () => {
-    const log = baseLog.withTag("RPR_037");
+  test("RPR-37: Response encryption failures | RP rejects a response encrypted with a wrong key", async () => {
+    const log = baseLog.withTag("RPR-37");
     const DESCRIPTION =
       "RP correctly rejected response with wrong encryption key";
     log.start("Conformance test: Response encryption failures");
@@ -244,8 +244,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-38 — Invalid signatures
   // -----------------------------------------------------------------------
 
-  test("RPR_038: Invalid signatures | RP rejects a response with tampered JARM integrity", async () => {
-    const log = baseLog.withTag("RPR_038");
+  test("RPR-38: Invalid signatures | RP rejects a response with tampered JARM integrity", async () => {
+    const log = baseLog.withTag("RPR-38");
     const DESCRIPTION =
       "RP correctly rejected response with tampered signature";
     log.start("Conformance test: Invalid signatures");
@@ -286,8 +286,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-39 — Invalid nonce values
   // -----------------------------------------------------------------------
 
-  test("RPR_039: Invalid nonce values | RP rejects a response containing a nonce mismatch", async () => {
-    const log = baseLog.withTag("RPR_039");
+  test("RPR-39: Invalid nonce values | RP rejects a response containing a nonce mismatch", async () => {
+    const log = baseLog.withTag("RPR-39");
     const DESCRIPTION = "RP correctly rejected response with mismatched nonce";
     log.start("Conformance test: Invalid nonce values");
 
@@ -368,8 +368,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-49 — Unsupported content types
   // -----------------------------------------------------------------------
 
-  test("RPR_049: Unsupported content types | RP rejects a response posted with an unsupported Content-Type", async () => {
-    const log = baseLog.withTag("RPR_049");
+  test("RPR-49: Unsupported content types | RP rejects a response posted with an unsupported Content-Type", async () => {
+    const log = baseLog.withTag("RPR-49");
     const DESCRIPTION =
       "RP correctly rejected response with unsupported Content-Type";
     log.start("Conformance test: Unsupported content types");
@@ -399,8 +399,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-52 — Response decryption failures
   // -----------------------------------------------------------------------
 
-  test("RPR_052: Response decryption failures | RP rejects malformed JWE content", async () => {
-    const log = baseLog.withTag("RPR_052");
+  test("RPR-52: Response decryption failures | RP rejects malformed JWE content", async () => {
+    const log = baseLog.withTag("RPR-52");
     const DESCRIPTION = "RP correctly rejected response with malformed JWE";
     log.start("Conformance test: Response decryption failures");
 
@@ -427,8 +427,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-60 — Invalid HTTP methods
   // -----------------------------------------------------------------------
 
-  test("RPR_060: Invalid HTTP methods | RP rejects GET request to response_uri", async () => {
-    const log = baseLog.withTag("RPR_060");
+  test("RPR-60: Invalid HTTP methods | RP rejects GET request to response_uri", async () => {
+    const log = baseLog.withTag("RPR-60");
     const DESCRIPTION = "RP correctly rejected GET request to response_uri";
     log.start("Conformance test: Invalid HTTP methods (GET)");
 
@@ -453,8 +453,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-63 — Response signature failures
   // -----------------------------------------------------------------------
 
-  test("RPR_063: Response signature failures | RP rejects a response whose JARM ciphertext has been corrupted", async () => {
-    const log = baseLog.withTag("RPR_063");
+  test("RPR-63: Response signature failures | RP rejects a response whose JARM ciphertext has been corrupted", async () => {
+    const log = baseLog.withTag("RPR-63");
     const DESCRIPTION =
       "RP correctly rejected response with corrupted ciphertext";
     log.start("Conformance test: Response signature failures");
@@ -491,8 +491,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-65 — Invalid JWT signatures
   // -----------------------------------------------------------------------
 
-  test("RPR_065: Invalid JWT signatures | RP rejects a response whose JWT integrity is deliberately broken", async () => {
-    const log = baseLog.withTag("RPR_065");
+  test("RPR-65: Invalid JWT signatures | RP rejects a response whose JWT integrity is deliberately broken", async () => {
+    const log = baseLog.withTag("RPR-65");
     const DESCRIPTION =
       "RP correctly rejected response with broken JWT integrity";
     log.start("Conformance test: Invalid JWT signatures");
@@ -522,8 +522,8 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // RPR-66 — Invalid JWT claims
   // -----------------------------------------------------------------------
 
-  test("RPR_066: Invalid JWT claims | RP rejects a response with invalid claim sets inside the encrypted payload", async () => {
-    const log = baseLog.withTag("RPR_066");
+  test("RPR-66: Invalid JWT claims | RP rejects a response with invalid claim sets inside the encrypted payload", async () => {
+    const log = baseLog.withTag("RPR-66");
     const DESCRIPTION =
       "RP correctly rejected response with invalid JWT claims";
     log.start("Conformance test: Invalid JWT claims");
@@ -574,9 +574,9 @@ describe(`[${testConfig.name}] Presentation Authorization Request Validation`, (
   // -----------------------------------------------------------------------
 
   test.each(["PUT", "DELETE", "PATCH"])(
-    "RPR_076: Unsupported HTTP methods | RP rejects PUT, DELETE, and PATCH requests to response_uri",
+    "RPR-76: Unsupported HTTP methods | RP rejects PUT, DELETE, and PATCH requests to response_uri",
     async (method) => {
-      const log = baseLog.withTag("RPR_076");
+      const log = baseLog.withTag("RPR-76");
       const DESCRIPTION = "RP correctly rejected unsupported HTTP methods";
       log.start("Conformance test: Unsupported HTTP methods");
 

--- a/tests/conformance/presentation/happy.presentation.spec.ts
+++ b/tests/conformance/presentation/happy.presentation.spec.ts
@@ -43,8 +43,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
 
   useTestSummary(baseLog, testConfig.name);
 
-  test("RPR003: Relying Party issues the QR-Code containing an URL using the base url provided within its metadata.", () => {
-    const log = baseLog.withTag("RPR003");
+  test("RPR-03: Relying Party issues the QR-Code containing an URL using the base url provided within its metadata.", () => {
+    const log = baseLog.withTag("RPR-03");
 
     log.start(
       "Conformance test: Verifying QR-Code URL alignment with RP metadata",
@@ -72,7 +72,7 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
       expect(parsedQrCode?.clientId).toBeDefined();
       if (!parsedQrCode?.clientId) {
         throw new Error(
-          "RPR006 precondition failed: parsedQrCode.clientId is undefined. " +
+          "RPR-06 precondition failed: parsedQrCode.clientId is undefined. " +
             "The authorization request QR code did not contain a client_id.",
         );
       }
@@ -96,8 +96,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR009: Relying Party accepts defaults to GET method.", () => {
-    const log = baseLog.withTag("RPR009");
+  test("RPR-09: Relying Party accepts defaults to GET method.", () => {
+    const log = baseLog.withTag("RPR-09");
 
     log.start(
       "Conformance test: Verifying HTTP GET method support for request objects",
@@ -140,8 +140,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR012: Relying Party receives and validates response with state and nonce values.", () => {
-    const log = baseLog.withTag("RPR012");
+  test("RPR-12: Relying Party receives and validates response with state and nonce values.", () => {
+    const log = baseLog.withTag("RPR-12");
 
     log.start(
       "Conformance test: Verifying state and nonce parameter presence and format",
@@ -177,8 +177,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR019: User is redirected correctly, the endpoint works.", () => {
-    const log = baseLog.withTag("RPR019");
+  test("RPR-19: User is redirected correctly, the endpoint works.", () => {
+    const log = baseLog.withTag("RPR-19");
 
     log.start(
       "Conformance test: Verifying redirect URI functionality and response code",
@@ -225,8 +225,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR078: Wallet Attestation request correctly uses standard DCQL query.", () => {
-    const log = baseLog.withTag("RPR078");
+  test("RPR-78: Wallet Attestation request correctly uses standard DCQL query.", () => {
+    const log = baseLog.withTag("RPR-78");
 
     log.start(
       "Conformance test: Verifying DCQL query standard format compliance",
@@ -263,8 +263,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR079: claims parameter is not included in DCQL query for Wallet Attestation.", () => {
-    const log = baseLog.withTag("RPR079");
+  test("RPR-79: claims parameter is not included in DCQL query for Wallet Attestation.", () => {
+    const log = baseLog.withTag("RPR-79");
 
     log.start(
       "Conformance test: Verifying Wallet Attestation does not include claims parameter",
@@ -327,8 +327,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR080: vct_values parameter is correctly required in DCQL query.", () => {
-    const log = baseLog.withTag("RPR080");
+  test("RPR-80: vct_values parameter is correctly required in DCQL query.", () => {
+    const log = baseLog.withTag("RPR-80");
 
     log.start(
       "Conformance test: Verifying vct_values presence in DCQL credentials",
@@ -392,8 +392,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR083: Relying Party correctly provides and handles redirect_uri.", () => {
-    const log = baseLog.withTag("RPR083");
+  test("RPR-83: Relying Party correctly provides and handles redirect_uri.", () => {
+    const log = baseLog.withTag("RPR-83");
 
     log.start(
       "Conformance test: Verifying response_uri and redirect_uri handling",
@@ -450,8 +450,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR089: JWT typ parameter is correctly set to oauth-authz-req+jwt.", () => {
-    const log = baseLog.withTag("RPR089");
+  test("RPR-89: JWT typ parameter is correctly set to oauth-authz-req+jwt.", () => {
+    const log = baseLog.withTag("RPR-89");
 
     log.start("Conformance test: Verifying JWT typ header parameter");
 
@@ -477,8 +477,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR090: response_mode parameter is correctly set to direct_post.jwt.", () => {
-    const log = baseLog.withTag("RPR090");
+  test("RPR-90: response_mode parameter is correctly set to direct_post.jwt.", () => {
+    const log = baseLog.withTag("RPR-90");
 
     log.start("Conformance test: Verifying response_mode parameter value");
 
@@ -502,8 +502,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR091: response_type parameter is correctly set to vp_token.", () => {
-    const log = baseLog.withTag("RPR091");
+  test("RPR-91: response_type parameter is correctly set to vp_token.", () => {
+    const log = baseLog.withTag("RPR-91");
 
     log.start("Conformance test: Verifying response_type parameter value");
 
@@ -527,8 +527,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR092: Relying Party sends Authorization Response to correct response_uri endpoint.", () => {
-    const log = baseLog.withTag("RPR092");
+  test("RPR-92: Relying Party sends Authorization Response to correct response_uri endpoint.", () => {
+    const log = baseLog.withTag("RPR-92");
 
     log.start(
       "Conformance test: Verifying authorization response submission to response_uri",
@@ -561,8 +561,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR093: nonce parameter has sufficient entropy with at least 32 characters.", () => {
-    const log = baseLog.withTag("RPR093");
+  test("RPR-93: nonce parameter has sufficient entropy with at least 32 characters.", () => {
+    const log = baseLog.withTag("RPR-93");
 
     log.start("Conformance test: Verifying nonce entropy requirements");
 
@@ -587,8 +587,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
     }
   });
 
-  test("RPR094: JWT exp parameter is correctly set and not expired.", () => {
-    const log = baseLog.withTag("RPR094");
+  test("RPR-94: JWT exp parameter is correctly set and not expired.", () => {
+    const log = baseLog.withTag("RPR-94");
 
     log.start("Conformance test: Verifying JWT expiration timestamp validity");
 

--- a/tests/conformance/presentation/redirect-uri.presentation.spec.ts
+++ b/tests/conformance/presentation/redirect-uri.presentation.spec.ts
@@ -67,9 +67,9 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
 
   // NOTE: This test verifies path-level rejection only. Host-level redirect_uri
   // security (unattested host) cannot be tested without RP-side DNS control.
-  // See IT-Wallet spec RPR_020 for full scenario.
-  test("RPR_020: Invalid redirect_uri handling | RP rejects when wallet follows a redirect to an invalid target", async () => {
-    const log = baseLog.withTag("RPR_020");
+  // See IT-Wallet spec RPR-20 for full scenario.
+  test("RPR-20: Invalid redirect_uri handling | RP rejects when wallet follows a redirect to an invalid target", async () => {
+    const log = baseLog.withTag("RPR-20");
     const DESCRIPTION = "RP securely rejects invalid redirect_uri overrides";
     log.start("Conformance test: Invalid redirect_uri handling");
 
@@ -98,8 +98,8 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
   // RPR-29 — Invalid response codes
   // -----------------------------------------------------------------------
 
-  test("RPR_029: Invalid response codes | RP gracefully handles invalid response_code in redirect", async () => {
-    const log = baseLog.withTag("RPR_029");
+  test("RPR-29: Invalid response codes | RP gracefully handles invalid response_code in redirect", async () => {
+    const log = baseLog.withTag("RPR-29");
     const DESCRIPTION = "RP gracefully handles invalid response_code replays";
     log.start("Conformance test: Invalid response codes");
 
@@ -144,8 +144,8 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
   // RPR-41 — Missing response parameters
   // -----------------------------------------------------------------------
 
-  test("RPR_041: Missing response parameters | RP rejects a response_uri POST that omits the 'response' parameter", async () => {
-    const log = baseLog.withTag("RPR_041");
+  test("RPR-41: Missing response parameters | RP rejects a response_uri POST that omits the 'response' parameter", async () => {
+    const log = baseLog.withTag("RPR-41");
     const DESCRIPTION =
       "RP correctly detects missing required response parameters";
     log.start("Conformance test: Missing response parameters");
@@ -173,8 +173,8 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
   // RPR-64 — Response format errors
   // -----------------------------------------------------------------------
 
-  test("RPR_064: Response format errors | RP rejects a malformed form payload to response_uri", async () => {
-    const log = baseLog.withTag("RPR_064");
+  test("RPR-64: Response format errors | RP rejects a malformed form payload to response_uri", async () => {
+    const log = baseLog.withTag("RPR-64");
     const DESCRIPTION = "RP rejects malformed form/JARM payloads";
     log.start("Conformance test: Response format errors");
 
@@ -201,8 +201,8 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
   // RPR-98 — Error response content type
   // -----------------------------------------------------------------------
 
-  test("RPR_098: Error response content type | RP returns application/json for error responses on response_uri", async () => {
-    const log = baseLog.withTag("RPR_098");
+  test("RPR-98: Error response content type | RP returns application/json for error responses on response_uri", async () => {
+    const log = baseLog.withTag("RPR-98");
     const DESCRIPTION = "RP returns application/json for error responses";
     log.start("Conformance test: Error response content type");
 
@@ -239,8 +239,8 @@ describe(`[${testConfig.name}] Presentation Redirect URI Validation Tests`, () =
   // RPR-99 — Error response parameters
   // -----------------------------------------------------------------------
 
-  test("RPR_099: Error response parameters | RP includes error and error_description in error responses", async () => {
-    const log = baseLog.withTag("RPR_099");
+  test("RPR-99: Error response parameters | RP includes error and error_description in error responses", async () => {
+    const log = baseLog.withTag("RPR-99");
     const DESCRIPTION = "RP includes error and error_description parameters";
     log.start("Conformance test: Error response parameters");
 


### PR DESCRIPTION
#### Motivation and Context

This PR standardizes the naming convention for Relying Party Requirements (RPR) test identifiers across the presentation conformance suite.

Previously, test tags and log identifiers used inconsistent formats (e.g., RPR_025, RPR003). These have been refactored to a unified RPR-XX format (e.g., RPR-25, RPR-03) to ensure:
   - Consistency: Aligning the codebase with the official requirement naming standards.
   - Readability: Improving the clarity of test logs and reports.
   - Traceability: Facilitating easier mapping between conformance tests and the requirements documentation.

The changes are strictly limited to string identifiers in test names and logging tags within the presentation spec files.


JIRA Ticket: WLEO-1240

Resolve https://github.com/pagopa/wallet-conformance-test/issues/146
