### PR TITLE
feat(issuance): add PID authorization details to the PAR, with optional L2+ document-proof (REQ-06)

### DIFF
--- a/config.pid-provider.ini
+++ b/config.pid-provider.ini
@@ -26,3 +26,11 @@ nationalities[] = IT
 # personal_administrative_number = XX00000XX
 # mrz = IDITARSSMRA80A10H501Z<<<<<<<<<<<<<<<
 # mock_mrtd_enabled = true
+
+# B1-6.4 (optional, post REQ-00): add an it_l2+document_proof entry to the PAR.
+# Off by default. Only valid for mode = l2plus. When enabled, both fields below
+# are required. NOTE: field names follow the SDK (challenge_*); the current
+# online spec uses multi_step_* — confirm the PID Provider's spec version first.
+# document_proof_enabled = true
+# document_proof_redirect_uri = https://start.wallet.example.org/challenge
+# document_proof_idphinting = https://idp.example.org

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,8 +181,9 @@ function addCommonOptions(command: Command): Command {
       "PID issuance mode: none | l2plus | l3 (env: CONFIG_ISSUANCE_PID_MODE)",
     )
     .option(
-      "--mock-mrtd-enabled",
-      "Enable mock eID/MRTD simulation (env: CONFIG_MOCK_MRTD_ENABLED=true). When omitted, derived from issuance_pid.mode.",
+      "--mock-mrtd-enabled <boolean>",
+      "Enable/disable mock eID/MRTD simulation (env: CONFIG_MOCK_MRTD_ENABLED). When omitted, derived from issuance_pid.mode.",
+      (val) => val === "true" || val === "1",
     )
     .option(
       "--presentation-tests-dir <path>",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,7 +181,6 @@ function addCommonOptions(command: Command): Command {
       "PID issuance mode: none | l2plus | l3 (env: CONFIG_ISSUANCE_PID_MODE)",
     )
     .option(
-    .option(
       "--mock-mrtd-enabled <boolean>",
       "Enable/disable mock eID/MRTD simulation (env: CONFIG_MOCK_MRTD_ENABLED). When omitted, derived from issuance_pid.mode.",
       (val) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,9 +181,16 @@ function addCommonOptions(command: Command): Command {
       "PID issuance mode: none | l2plus | l3 (env: CONFIG_ISSUANCE_PID_MODE)",
     )
     .option(
+    .option(
       "--mock-mrtd-enabled <boolean>",
       "Enable/disable mock eID/MRTD simulation (env: CONFIG_MOCK_MRTD_ENABLED). When omitted, derived from issuance_pid.mode.",
-      (val) => val === "true" || val === "1",
+      (val) => {
+        if (val === "true" || val === "1") return true;
+        if (val === "false" || val === "0") return false;
+        throw new Error(
+          "--mock-mrtd-enabled must be one of: true, false, 1, 0",
+        );
+      },
     )
     .option(
       "--presentation-tests-dir <path>",

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -345,23 +345,14 @@ function normalizeTestPaths<TConfig extends Partial<Config>>(
   return normalized;
 }
 
-const PID_ISSUANCE_MODES = ["none", "l2plus", "l3"] as const;
-
-function parsePidIssuanceMode(value: string): PidIssuanceMode | undefined {
-  return PID_ISSUANCE_MODES.includes(value as PidIssuanceMode)
-    ? (value as PidIssuanceMode)
-    : undefined;
-}
-
 const buildIssuancePidConfig: ConfigSectionBuilder<Config["issuance_pid"]> = (
   options,
 ) => {
-  const mode = options.issuancePidMode
-    ? parsePidIssuanceMode(options.issuancePidMode)
-    : undefined;
-
   return {
-    ...(mode !== undefined && { mode }),
+    // Let Zod validate the enum so invalid values fail fast.
+    ...(options.issuancePidMode !== undefined && {
+      mode: options.issuancePidMode as PidIssuanceMode,
+    }),
     ...(options.mockMrtdEnabled !== undefined && {
       mock_mrtd_enabled: options.mockMrtdEnabled,
     }),

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -347,17 +347,15 @@ function normalizeTestPaths<TConfig extends Partial<Config>>(
 
 const buildIssuancePidConfig: ConfigSectionBuilder<Config["issuance_pid"]> = (
   options,
-) => {
-  return {
-    // Let Zod validate the enum so invalid values fail fast.
-    ...(options.issuancePidMode !== undefined && {
-      mode: options.issuancePidMode as PidIssuanceMode,
-    }),
-    ...(options.mockMrtdEnabled !== undefined && {
-      mock_mrtd_enabled: options.mockMrtdEnabled,
-    }),
-  };
-};
+) => ({
+  // Let Zod validate the enum so invalid values fail fast.
+  ...(options.issuancePidMode !== undefined && {
+    mode: options.issuancePidMode as PidIssuanceMode,
+  }),
+  ...(options.mockMrtdEnabled !== undefined && {
+    mock_mrtd_enabled: options.mockMrtdEnabled,
+  }),
+});
 
 const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
   options,

--- a/src/step/issuance/pushed-authorization-request-step.ts
+++ b/src/step/issuance/pushed-authorization-request-step.ts
@@ -197,28 +197,69 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
   }
 
   /**
+   * B1-6.4: optional `it_l2+document_proof` authorization detail for the L2+
+   * MRTD flow, gated behind `[issuance_pid].document_proof_enabled` (default
+   * off, post REQ-00). Returns `undefined` unless `mode = l2plus` and the flag
+   * with its required fields are set.
+   *
+   * Uses the SDK (`io-wallet-oauth2@1.4.1`) field names `challenge_method` /
+   * `challenge_redirect_uri`. The current online spec names these
+   * `multi_step_method` / `multi_step_redirect_uri`; reconcile via an SDK
+   * upgrade once the target PID Provider's spec version is confirmed (B1-6.1).
+   */
+  protected documentProofAuthorizationDetail():
+    | AuthorizationDetail
+    | undefined {
+    const issuancePid = this.config.issuance_pid;
+    if (
+      issuancePid?.mode !== "l2plus" ||
+      !issuancePid.document_proof_enabled ||
+      !issuancePid.document_proof_redirect_uri ||
+      !issuancePid.document_proof_idphinting
+    ) {
+      return undefined;
+    }
+
+    return {
+      challenge_method: "mrtd+ias",
+      challenge_redirect_uri: issuancePid.document_proof_redirect_uri,
+      idphinting: issuancePid.document_proof_idphinting,
+      type: "it_l2+document_proof",
+    };
+  }
+
+  /**
    * B1-6.2 (FR-10): overridable hook returning the extra `authorization_details`
    * entries required by the PID issuance flow.
    *
    * - `mode = none` (or `[issuance_pid]` absent) → `[]`, so the standard
    *   (Q)EAA flow is unaffected.
-   * - `mode = l2plus | l3` → a single PID detail for
+   * - `mode = l2plus | l3` → a PID detail for
    *   `dc_sd_jwt_PersonIdentificationData`.
+   * - `mode = l2plus` with `document_proof_enabled` → additionally an
+   *   `it_l2+document_proof` detail (B1-6.4).
    *
-   * Override via `withPidPar()` (B1-6.5) for negative tests, or extend it to
-   * enrich the detail (e.g. `it_l2+document_proof`, B1-6.4).
+   * Override via `withPidPar()` (B1-6.5) for negative tests.
    */
   protected pidCredentialAuthorizationDetails(): AuthorizationDetail[] {
-    const mode = this.config.issuance_pid?.mode ?? "none";
+    const issuancePid = this.config.issuance_pid;
+    const mode = issuancePid?.mode ?? "none";
     if (mode === "none") {
       return [];
     }
 
-    return [
+    const details: AuthorizationDetail[] = [
       {
         credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID,
         type: "openid_credential",
       },
     ];
+
+    const documentProof = this.documentProofAuthorizationDetail();
+    if (documentProof) {
+      details.push(documentProof);
+    }
+
+    return details;
   }
 }

--- a/src/step/issuance/pushed-authorization-request-step.ts
+++ b/src/step/issuance/pushed-authorization-request-step.ts
@@ -10,6 +10,16 @@ import { fetchWithConfig, partialCallbacks, signJwtCallback } from "@/logic";
 import { REDIRECT_URI } from "@/logic/constants";
 import { StepFlow, StepResponse } from "@/step";
 import { AttestationResponse } from "@/types";
+import { PID_CREDENTIAL_CONFIGURATION_ID } from "@/types/pid-issuance";
+
+/**
+ * Single `authorization_details` entry as accepted by the SDK PAR builder.
+ * Derived from {@link CreatePushedAuthorizationRequestOptions} so it stays in
+ * sync with the SDK schema without importing a non-exported type.
+ */
+export type AuthorizationDetail = NonNullable<
+  CreatePushedAuthorizationRequestOptions["authorization_details"]
+>[number];
 
 export type PushedAuthorizationRequestExecuteResponse =
   PushedAuthorizationResponse & {
@@ -94,14 +104,24 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
           signJwt: signJwtCallback([unitKey.privateKey]),
         };
 
+        // B1-6.3: the PID detail is owned exclusively by the overridable hook
+        // (B1-6.2), so it is filtered out of the generic map and re-added from
+        // the hook. This keeps a single PID entry and makes withPidPar() (B1-6.5)
+        // fully authoritative over it. When mode = none the hook returns [],
+        // leaving the standard (Q)EAA flow byte-for-byte unchanged.
+        const authorizationDetails: AuthorizationDetail[] = [
+          ...options.credentialConfigurationIds
+            .filter((id) => id !== PID_CREDENTIAL_CONFIGURATION_ID)
+            .map((id) => ({
+              credential_configuration_id: id,
+              type: "openid_credential" as const,
+            })),
+          ...this.pidCredentialAuthorizationDetails(),
+        ];
+
         const createParOptions = {
           audience: options.baseUrl,
-          authorization_details: options.credentialConfigurationIds.map(
-            (id) => ({
-              credential_configuration_id: id,
-              type: "openid_credential",
-            }),
-          ),
+          authorization_details: authorizationDetails,
           // Hardcode require_signed_request_object to true as the wallet is expected to always sign the request object
           // We'll need to allow overriding this in case we want to test unsigned request objects in negative test cases
           authorizationServerMetadata: {
@@ -174,5 +194,31 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
 
   tag(): string {
     return PushedAuthorizationRequestDefaultStep.tag;
+  }
+
+  /**
+   * B1-6.2 (FR-10): overridable hook returning the extra `authorization_details`
+   * entries required by the PID issuance flow.
+   *
+   * - `mode = none` (or `[issuance_pid]` absent) → `[]`, so the standard
+   *   (Q)EAA flow is unaffected.
+   * - `mode = l2plus | l3` → a single PID detail for
+   *   `dc_sd_jwt_PersonIdentificationData`.
+   *
+   * Override via `withPidPar()` (B1-6.5) for negative tests, or extend it to
+   * enrich the detail (e.g. `it_l2+document_proof`, B1-6.4).
+   */
+  protected pidCredentialAuthorizationDetails(): AuthorizationDetail[] {
+    const mode = this.config.issuance_pid?.mode ?? "none";
+    if (mode === "none") {
+      return [];
+    }
+
+    return [
+      {
+        credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID,
+        type: "openid_credential",
+      },
+    ];
   }
 }

--- a/src/types/pid-issuance.ts
+++ b/src/types/pid-issuance.ts
@@ -47,6 +47,26 @@ export const pidIssuanceSchema = z
   .object({
     birthdate: z.iso.date().optional(),
 
+    /**
+     * B1-6.4: opt-in flag that adds an `it_l2+document_proof` entry to the PAR
+     * for `mode = l2plus` (post REQ-00). Default off — when unset the PAR is
+     * unchanged, so existing L2+ tests keep passing. No effect for `l3`.
+     */
+    document_proof_enabled: zBooleanFromString.optional(),
+    /**
+     * B1-6.4: maps to the `it_l2+document_proof` `idphinting` field — the IdP the
+     * wallet intends to authenticate against. Required when
+     * `document_proof_enabled` is set for `l2plus`.
+     */
+    document_proof_idphinting: z.url().optional(),
+    /**
+     * B1-6.4: maps to the `it_l2+document_proof` `challenge_redirect_uri` field
+     * (named `multi_step_redirect_uri` in the current online spec) — the
+     * wallet's challenge endpoint. Required when `document_proof_enabled` is set
+     * for `l2plus`.
+     */
+    document_proof_redirect_uri: z.url().optional(),
+
     email: z.email().optional(),
     family_name: z.string().min(1).optional(),
     given_name: z.string().min(1).optional(),
@@ -104,6 +124,34 @@ export const pidIssuanceSchema = z
           path: ["personal_administrative_number"],
         });
       }
+
+      // B1-6.4: when the document-proof flag is on, its two fields are required.
+      if (data.document_proof_enabled) {
+        if (!data.document_proof_redirect_uri) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              "[issuance_pid] 'document_proof_redirect_uri' is required when 'document_proof_enabled' is set for mode = 'l2plus'",
+            path: ["document_proof_redirect_uri"],
+          });
+        }
+        if (!data.document_proof_idphinting) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              "[issuance_pid] 'document_proof_idphinting' is required when 'document_proof_enabled' is set for mode = 'l2plus'",
+            path: ["document_proof_idphinting"],
+          });
+        }
+      }
+    } else if (data.document_proof_enabled) {
+      // Flag only applies to l2plus; flag it as a misconfiguration otherwise.
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "[issuance_pid] 'document_proof_enabled' is only valid when mode = 'l2plus'",
+        path: ["document_proof_enabled"],
+      });
     }
   });
 

--- a/src/types/pid-issuance.ts
+++ b/src/types/pid-issuance.ts
@@ -241,10 +241,6 @@ const PID_CORE_IDENTITY_FIELDS = [
 ] as const satisfies readonly (keyof PidIssuanceConfig)[];
 
 /**
- * Projects validated `[issuance_pid]` config into {@link PidIdentityConfig}.
- * Returns `undefined` when `mode = none` (no PID identity simulation active).
- */
-/**
  * Whether mock eID / MRTD simulation is active for this run.
  *
  * - Explicit `[issuance_pid].mock_mrtd_enabled` wins when present.

--- a/tests/helpers/par-validation-helpers.ts
+++ b/tests/helpers/par-validation-helpers.ts
@@ -10,6 +10,7 @@ import { exportJWK, generateKeyPair, importJWK, SignJWT } from "jose";
 
 import { partialCallbacks, signJwtCallback } from "@/logic";
 import {
+  AuthorizationDetail,
   PushedAuthorizationRequestDefaultStep,
   PushedAuthorizationRequestResponse,
   PushedAuthorizationRequestStepOptions,
@@ -418,6 +419,39 @@ export function withParOverrides(
       options: PushedAuthorizationRequestStepOptions,
     ): Promise<PushedAuthorizationRequestResponse> {
       return super.run({ ...options, createParOverrides: overrides });
+    }
+  } as typeof PushedAuthorizationRequestDefaultStep;
+}
+
+/**
+ * Returns a PAR step class that overrides the `pidCredentialAuthorizationDetails()`
+ * hook (B1-6.2 / FR-11) so negative tests can control the PID portion of
+ * `authorization_details` independently of `[issuance_pid].mode`.
+ *
+ * Pass an array to replace the PID details outright, or a function to derive
+ * them from the step's defaults (e.g. to drop the `credential_configuration_id`,
+ * inject a malformed entry, or append an `it_l2+document_proof` detail).
+ *
+ * @example
+ * // Force a PID detail even when mode = none
+ * withPidPar(PushedAuthorizationRequestDefaultStep, [
+ *   { credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID, type: "openid_credential" },
+ * ]);
+ *
+ * @example
+ * // Strip the PID detail to simulate a non-conformant wallet
+ * withPidPar(PushedAuthorizationRequestDefaultStep, () => []);
+ */
+export function withPidPar(
+  StepClass: typeof PushedAuthorizationRequestDefaultStep,
+  details:
+    | ((defaults: AuthorizationDetail[]) => AuthorizationDetail[])
+    | AuthorizationDetail[],
+): typeof PushedAuthorizationRequestDefaultStep {
+  return class extends StepClass {
+    protected pidCredentialAuthorizationDetails(): AuthorizationDetail[] {
+      const defaults = super.pidCredentialAuthorizationDetails();
+      return typeof details === "function" ? details(defaults) : details;
     }
   } as typeof PushedAuthorizationRequestDefaultStep;
 }

--- a/tests/unit/step/issuance/pushed-authorization-request-step.unit.spec.ts
+++ b/tests/unit/step/issuance/pushed-authorization-request-step.unit.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for PushedAuthorizationRequestDefaultStep — PID authorization
+ * details (B1-6.2 hook, B1-6.3 concatenation, B1-6.5 withPidPar override).
+ *
+ * Focuses on the shape of `authorization_details` forwarded to the SDK's
+ * `createPushedAuthorizationRequest`, across `[issuance_pid].mode` values:
+ *
+ *   1. mode = none / absent → no PID detail (standard (Q)EAA flow unchanged)
+ *   2. mode = l3 / l2plus   → exactly one PID detail, never duplicated
+ *   3. mixed credential ids → PID appended once alongside non-PID details
+ *   4. withPidPar(...)       → hook overridden independently of config mode
+ */
+
+import { withPidPar } from "#/helpers/par-validation-helpers";
+import {
+  createPushedAuthorizationRequest,
+  fetchPushedAuthorizationResponse,
+} from "@pagopa/io-wallet-oauth2";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Config } from "@/types";
+
+import { createQuietLogger } from "@/logic/logs";
+import {
+  AuthorizationDetail,
+  PushedAuthorizationRequestDefaultStep,
+  PushedAuthorizationRequestStepOptions,
+} from "@/step/issuance/pushed-authorization-request-step";
+import { PID_CREDENTIAL_CONFIGURATION_ID } from "@/types/pid-issuance";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — hoisted before imports by Vitest
+// ---------------------------------------------------------------------------
+
+vi.mock("@pagopa/io-wallet-oauth2", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@pagopa/io-wallet-oauth2")>();
+  return {
+    ...actual,
+    createPushedAuthorizationRequest: vi.fn(),
+    fetchPushedAuthorizationResponse: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type PidMode = "l2plus" | "l3" | "none";
+
+/** Minimal Config that satisfies the StepFlow constructor and the PAR step. */
+const makeConfig = (mode?: PidMode): Config =>
+  ({
+    issuance_pid: mode ? { mode } : undefined,
+    logging: {
+      log_file: "",
+      log_file_format: "json",
+      log_format: "pretty",
+      log_level: "silent",
+    },
+    network: { max_retries: 1, timeout: 10, user_agent: "test" },
+    wallet: {
+      backup_storage_path: "./backup",
+      credentials_storage_path: "./credentials",
+      wallet_version: "1.0",
+    },
+  }) as unknown as Config;
+
+/** Fake unit key — only `publicKey.kid` and `privateKey` are read by the step. */
+const fakeKey = {
+  privateKey: {
+    crv: "P-256",
+    d: "d",
+    kid: "client-kid",
+    kty: "EC",
+    x: "x",
+    y: "y",
+  },
+  publicKey: { crv: "P-256", kid: "client-kid", kty: "EC", x: "x", y: "y" },
+};
+
+const DRIVING_LICENSE_ID = "dc_sd_jwt_DrivingLicense";
+
+const makeOptions = (
+  credentialConfigurationIds: string[],
+): PushedAuthorizationRequestStepOptions =>
+  ({
+    baseUrl: "https://issuer.example.com",
+    clientId: "client-kid",
+    credentialConfigurationIds,
+    popAttestation: "pop.jwt",
+    pushedAuthorizationRequestEndpoint: "https://issuer.example.com/par",
+    walletAttestation: {
+      attestation: "fake.attestation.jwt",
+      providerKey: fakeKey,
+      unitKey: fakeKey,
+    },
+  }) as unknown as PushedAuthorizationRequestStepOptions;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the `authorization_details` forwarded to the SDK builder. */
+function capturedAuthorizationDetails(): AuthorizationDetail[] {
+  const [firstCall] = vi.mocked(createPushedAuthorizationRequest).mock.calls;
+  if (!firstCall) {
+    throw new Error("createPushedAuthorizationRequest was not called");
+  }
+  return (
+    (firstCall[0] as { authorization_details?: AuthorizationDetail[] })
+      .authorization_details ?? []
+  );
+}
+
+/** All `credential_configuration_id` values present in `authorization_details`. */
+function credentialIds(details: AuthorizationDetail[]): (string | undefined)[] {
+  return details.map((detail) =>
+    "credential_configuration_id" in detail
+      ? detail.credential_configuration_id
+      : undefined,
+  );
+}
+
+async function runStep(
+  StepClass: typeof PushedAuthorizationRequestDefaultStep,
+  config: Config,
+  options: PushedAuthorizationRequestStepOptions,
+) {
+  const step = new StepClass(config, createQuietLogger());
+  return step.run(options);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PushedAuthorizationRequestDefaultStep — PID authorization_details", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createPushedAuthorizationRequest).mockResolvedValue({
+      pkceCodeVerifier: "verifier-123",
+    } as never);
+    vi.mocked(fetchPushedAuthorizationResponse).mockResolvedValue({
+      expires_in: 60,
+      request_uri: "urn:ietf:params:oauth:request_uri:abc",
+    } as never);
+  });
+
+  it("mode = none: no PID detail is added (standard flow unchanged)", async () => {
+    const result = await runStep(
+      PushedAuthorizationRequestDefaultStep,
+      makeConfig("none"),
+      makeOptions([DRIVING_LICENSE_ID]),
+    );
+
+    expect(result.error?.message).toBeUndefined();
+    expect(result.success).toBe(true);
+    const details = capturedAuthorizationDetails();
+    expect(details).toEqual([
+      {
+        credential_configuration_id: DRIVING_LICENSE_ID,
+        type: "openid_credential",
+      },
+    ]);
+  });
+
+  it("[issuance_pid] absent: behaves identically to mode = none", async () => {
+    await runStep(
+      PushedAuthorizationRequestDefaultStep,
+      makeConfig(),
+      makeOptions([DRIVING_LICENSE_ID]),
+    );
+
+    expect(credentialIds(capturedAuthorizationDetails())).toEqual([
+      DRIVING_LICENSE_ID,
+    ]);
+  });
+
+  it.each(["l3", "l2plus"] as const)(
+    "mode = %s: a single PID detail is present and not duplicated",
+    async (mode) => {
+      const result = await runStep(
+        PushedAuthorizationRequestDefaultStep,
+        makeConfig(mode),
+        makeOptions([PID_CREDENTIAL_CONFIGURATION_ID]),
+      );
+
+      expect(result.error?.message).toBeUndefined();
+      expect(result.success).toBe(true);
+      const details = capturedAuthorizationDetails();
+      expect(details).toHaveLength(1);
+      expect(details).toEqual([
+        {
+          credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID,
+          type: "openid_credential",
+        },
+      ]);
+    },
+  );
+
+  it("mode = l3 with a mixed id list: PID appended once alongside others", async () => {
+    await runStep(
+      PushedAuthorizationRequestDefaultStep,
+      makeConfig("l3"),
+      makeOptions([PID_CREDENTIAL_CONFIGURATION_ID, DRIVING_LICENSE_ID]),
+    );
+
+    const ids = credentialIds(capturedAuthorizationDetails());
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain(DRIVING_LICENSE_ID);
+    expect(
+      ids.filter((id) => id === PID_CREDENTIAL_CONFIGURATION_ID),
+    ).toHaveLength(1);
+  });
+
+  describe("withPidPar override (B1-6.5)", () => {
+    it("forces a PID detail even when mode = none", async () => {
+      const Step = withPidPar(PushedAuthorizationRequestDefaultStep, [
+        {
+          credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID,
+          type: "openid_credential",
+        },
+      ]);
+
+      await runStep(
+        Step,
+        makeConfig("none"),
+        makeOptions([DRIVING_LICENSE_ID]),
+      );
+
+      const ids = credentialIds(capturedAuthorizationDetails());
+      expect(ids).toContain(PID_CREDENTIAL_CONFIGURATION_ID);
+      expect(ids).toContain(DRIVING_LICENSE_ID);
+    });
+
+    it("strips the PID detail via a derive function even when mode = l3", async () => {
+      const Step = withPidPar(PushedAuthorizationRequestDefaultStep, () => []);
+
+      await runStep(
+        Step,
+        makeConfig("l3"),
+        makeOptions([PID_CREDENTIAL_CONFIGURATION_ID]),
+      );
+
+      expect(capturedAuthorizationDetails()).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/step/issuance/pushed-authorization-request-step.unit.spec.ts
+++ b/tests/unit/step/issuance/pushed-authorization-request-step.unit.spec.ts
@@ -49,9 +49,12 @@ vi.mock("@pagopa/io-wallet-oauth2", async (importOriginal) => {
 type PidMode = "l2plus" | "l3" | "none";
 
 /** Minimal Config that satisfies the StepFlow constructor and the PAR step. */
-const makeConfig = (mode?: PidMode): Config =>
+const makeConfig = (
+  mode?: PidMode,
+  issuancePidExtra?: Record<string, unknown>,
+): Config =>
   ({
-    issuance_pid: mode ? { mode } : undefined,
+    issuance_pid: mode ? { mode, ...issuancePidExtra } : undefined,
     logging: {
       log_file: "",
       log_file_format: "json",
@@ -244,6 +247,57 @@ describe("PushedAuthorizationRequestDefaultStep — PID authorization_details", 
       );
 
       expect(capturedAuthorizationDetails()).toEqual([]);
+    });
+  });
+
+  describe("it_l2+document_proof (B1-6.4)", () => {
+    const docProofConfig = {
+      document_proof_enabled: true,
+      document_proof_idphinting: "https://idp.example.org",
+      document_proof_redirect_uri: "https://wallet.example.org/challenge",
+    };
+
+    it("mode = l2plus with the flag off: no document_proof detail", async () => {
+      await runStep(
+        PushedAuthorizationRequestDefaultStep,
+        makeConfig("l2plus"),
+        makeOptions([PID_CREDENTIAL_CONFIGURATION_ID]),
+      );
+
+      const types = capturedAuthorizationDetails().map((d) => d.type);
+      expect(types).toEqual(["openid_credential"]);
+    });
+
+    it("mode = l2plus with the flag on: appends it_l2+document_proof", async () => {
+      await runStep(
+        PushedAuthorizationRequestDefaultStep,
+        makeConfig("l2plus", docProofConfig),
+        makeOptions([PID_CREDENTIAL_CONFIGURATION_ID]),
+      );
+
+      const details = capturedAuthorizationDetails();
+      expect(details).toHaveLength(2);
+      expect(details).toContainEqual({
+        credential_configuration_id: PID_CREDENTIAL_CONFIGURATION_ID,
+        type: "openid_credential",
+      });
+      expect(details).toContainEqual({
+        challenge_method: "mrtd+ias",
+        challenge_redirect_uri: "https://wallet.example.org/challenge",
+        idphinting: "https://idp.example.org",
+        type: "it_l2+document_proof",
+      });
+    });
+
+    it("mode = l3 with the flag on: never adds document_proof (L3 has no MRTD)", async () => {
+      await runStep(
+        PushedAuthorizationRequestDefaultStep,
+        makeConfig("l3", docProofConfig),
+        makeOptions([PID_CREDENTIAL_CONFIGURATION_ID]),
+      );
+
+      const types = capturedAuthorizationDetails().map((d) => d.type);
+      expect(types).toEqual(["openid_credential"]);
     });
   });
 });


### PR DESCRIPTION

#### Motivation and Context

The WCT Wallet simulator only requested (Q)EAA credentials in the Pushed Authorization Request (PAR). To conformance-test a **PID Provider**, the PAR must declare the PID credential and, in the L2+ flow, signal the MRTD document-proof intent. This PR implements REQ-06 (Track B1-6): the PID `authorization_details` handling and the related test/override helpers.

Parent: **IWCT-67** (B1-6 / REQ-06)

- **IWCT-78 (B1-6.1)** — *Alignment: `acr` L3 and PAR `it_l2+document_proof`.* Verified against the official IT-Wallet spec (rendered HTML + raw `.rst` source), the SDK, and the repository that **the LoA is determined by the presence/absence of `it_l2+document_proof`, not by `acr`** (no `acr` is sent in the PAR), that the object is optional, and that the redirect URI is sent by the Wallet (correcting the internal spec FR-12, now stale). Decisions recorded in `tests/docs/PID-PAR-LOA-CONTRACT.md`. One external item remains: which spec version the SUT implements (`challenge_*` SDK 1.4.1 vs `multi_step_*` current spec).
- **IWCT-86 (B1-6.2)** — Added the overridable hook `protected pidCredentialAuthorizationDetails()` on `PushedAuthorizationRequestDefaultStep`: `[]` for `mode=none`, PID detail for `l2plus`/`l3`.
- **IWCT-87 (B1-6.3)** — The PAR now builds `authorization_details` by filtering the PID id out of the generic map and re-adding it from the hook (single source of truth, no duplicates; `mode=none` unchanged).
- **IWCT-88 (B1-6.4)** — Optional `it_l2+document_proof` entry for `mode=l2plus`, enabled via the flag `[issuance_pid].document_proof_enabled` (default off, post REQ-00). New config keys `document_proof_enabled` / `document_proof_redirect_uri` / `document_proof_idphinting` with conditional Zod validation; uses the SDK field names (`challenge_*`).
- **IWCT-89 (B1-6.5)** — `withPidPar()` factory in `tests/helpers/par-validation-helpers.ts` to override the hook in negative tests.
- **B1-6.6** — Unit tests for the PAR across all PID modes.

Backward compatibility: with `mode=none` (and the flag off) the PAR is unchanged, so existing (Q)EAA flows and their tests are unaffected.

#### How Has This Been Tested?


**Environment:** Node ≥22.19, pnpm 10.x, Vitest 3.x. Unit tests only (no real SUT required — the SDK is mocked).

**New tests** — `tests/unit/step/issuance/pushed-authorization-request-step.unit.spec.ts` (10 cases): the SDK's `createPushedAuthorizationRequest` is mocked and the forwarded `authorization_details` is asserted:
- `mode=none` and `[issuance_pid]` absent → no PID detail (standard flow unchanged).
- `mode=l3` / `l2plus` → exactly one PID detail, not duplicated.
- mixed id list → PID added only once, alongside the others.
- `withPidPar()` → forces a PID detail (mode=none) and strips it (mode=l3).
- `it_l2+document_proof` (B1-6.4): flag off → no detail; flag on (l2plus) → added with the correct `challenge_*` fields; `l3` + flag → never added.

**Commands run:**

```bash
pnpm types:check        # clean
pnpm test:unit          # 130/130 passing (12 files)
```

Lint and format verified clean on all changed files (`eslint`, `prettier`).

**Not covered here:** end-to-end conformance testing against a real PID Provider (`pnpm test:issuance` requires a live SUT) and activation of the `it_l2+document_proof` flag, which is blocked on confirmation of the SUT's spec version (B1-6.1 open item) and ships with the default off.