### PR TITLE
fix: double-slash paths when fetching url

### DIFF
--- a/src/orchestrator/wallet-presentation-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-presentation-orchestrator-flow.ts
@@ -223,6 +223,10 @@ export class WalletPresentationOrchestratorFlow {
     return walletAttestation;
   }
 
+  private normalizeBaseUrl(url: string): string {
+    return new URL(url).href.replace(/\/+$/, "");
+  }
+
   private prepareBaseUrl(): string | undefined {
     if (!this.config.presentation.verifier) {
       const authorizeUrl = new URL(
@@ -246,14 +250,14 @@ export class WalletPresentationOrchestratorFlow {
         return undefined;
       }
 
-      const baseUrl = new URL(normalizedClientId.clientId);
+      const baseUrl = this.normalizeBaseUrl(normalizedClientId.clientId);
       this.log.debug(
-        `Using client_id from authorize_request_url as verifier baseUrl: ${baseUrl.href}`,
+        `Using client_id from authorize_request_url as verifier baseUrl: ${baseUrl}`,
       );
-      return baseUrl.href;
+      return baseUrl;
     }
 
-    return this.config.presentation.verifier;
+    return this.normalizeBaseUrl(this.config.presentation.verifier);
   }
 
   private printTestSuiteOnce(): void {

--- a/src/orchestrator/wallet-presentation-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-presentation-orchestrator-flow.ts
@@ -75,6 +75,39 @@ export class WalletPresentationOrchestratorFlow {
     return this.log;
   }
 
+  prepareBaseUrl(): string | undefined {
+    if (!this.config.presentation.verifier) {
+      const authorizeUrl = new URL(
+        this.config.presentation.authorize_request_url,
+      );
+      const clientId = authorizeUrl.searchParams.get("client_id");
+
+      if (!clientId) {
+        throw new Error(
+          "client_id parameter not found in authorize_request_url and verifier not configured",
+        );
+      }
+
+      // client_id may use a custom scheme prefix such as "openid_federation:https://example.com".
+      const normalizedClientId = extractClientIdPrefix(clientId);
+
+      if (!normalizedClientId.clientId.startsWith("https://")) {
+        this.log.warn(
+          `Skipping verifier metadata fetch: unsupported client_id format "${clientId}" (normalized: "${normalizedClientId.clientId}"). Expected a plain HTTPS URL or a single-colon prefixed scheme resolving to an HTTPS URL. Configure presentation.verifier explicitly to bypass client_id-derived metadata lookup.`,
+        );
+        return undefined;
+      }
+
+      const baseUrl = this.normalizeBaseUrl(normalizedClientId.clientId);
+      this.log.debug(
+        `Using client_id from authorize_request_url as verifier baseUrl: ${baseUrl}`,
+      );
+      return baseUrl;
+    }
+
+    return this.normalizeBaseUrl(this.config.presentation.verifier);
+  }
+
   async presentation(): Promise<PresentationFlowResponse> {
     this.resetResponses();
 
@@ -225,39 +258,6 @@ export class WalletPresentationOrchestratorFlow {
 
   private normalizeBaseUrl(url: string): string {
     return new URL(url).href.replace(/\/+$/, "");
-  }
-
-  prepareBaseUrl(): string | undefined {
-    if (!this.config.presentation.verifier) {
-      const authorizeUrl = new URL(
-        this.config.presentation.authorize_request_url,
-      );
-      const clientId = authorizeUrl.searchParams.get("client_id");
-
-      if (!clientId) {
-        throw new Error(
-          "client_id parameter not found in authorize_request_url and verifier not configured",
-        );
-      }
-
-      // client_id may use a custom scheme prefix such as "openid_federation:https://example.com".
-      const normalizedClientId = extractClientIdPrefix(clientId);
-
-      if (!normalizedClientId.clientId.startsWith("https://")) {
-        this.log.warn(
-          `Skipping verifier metadata fetch: unsupported client_id format "${clientId}" (normalized: "${normalizedClientId.clientId}"). Expected a plain HTTPS URL or a single-colon prefixed scheme resolving to an HTTPS URL. Configure presentation.verifier explicitly to bypass client_id-derived metadata lookup.`,
-        );
-        return undefined;
-      }
-
-      const baseUrl = this.normalizeBaseUrl(normalizedClientId.clientId);
-      this.log.debug(
-        `Using client_id from authorize_request_url as verifier baseUrl: ${baseUrl}`,
-      );
-      return baseUrl;
-    }
-
-    return this.normalizeBaseUrl(this.config.presentation.verifier);
   }
 
   private printTestSuiteOnce(): void {

--- a/tests/unit/orchestrator-partial-response.unit.spec.ts
+++ b/tests/unit/orchestrator-partial-response.unit.spec.ts
@@ -523,7 +523,7 @@ describe("WalletPresentationOrchestratorFlow.presentation()", () => {
     const result = await orchestrator.presentation();
 
     expect(fetchMetadataRun).toHaveBeenCalledWith({
-      baseUrl: "https://verifier.example.com/",
+      baseUrl: "https://verifier.example.com",
     });
     expect(result.success).toBe(false);
     expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);


### PR DESCRIPTION
## Summary

Fixes a bug where the `prepareBaseUrl()` method returned URLs with trailing slashes (e.g. `https://example.com/`), causing double-slash paths when segments were appended downstream.

## Changes

- Extracted a private `normalizeBaseUrl(url: string): string` helper that parses a URL and strips any trailing slashes.
- Applied it to both code paths in `prepareBaseUrl()`: the `client_id`-derived URL and the explicit `config.presentation.verifier` value.

## Testing

- All pre-commit / pre-push checks (format, lint, types) pass.
- Existing unit and conformance test suites are unaffected.