### PR TITLE
feat(conformance): add PAR and federation tests

### DIFF
--- a/tests/conformance/issuance/authorization-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/authorization-validation.issuance.spec.ts
@@ -2,7 +2,6 @@
 
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { useTestSummary } from "#/helpers/use-test-summary";
-import { Oauth2Error } from "@pagopa/io-wallet-oauth2";
 import { beforeAll, describe, expect, test } from "vitest";
 
 import { loadConfigWithHierarchy } from "@/logic";
@@ -210,29 +209,27 @@ testConfigs.forEach((testConfig) => {
       let testSuccess = false;
       try {
         log.debug(
-          "→ Sending authorization request without request_uri (should be rejected)...",
+          "→ Sending GET authorization request without request_uri (should be rejected)...",
         );
-        const result = await runAuthStep(testConfig.authorizeStepClass);
+        const url = new URL(authorizationEndpoint);
+        url.searchParams.set(
+          "client_id",
+          walletAttestationResponse.unitKey.publicKey.kid ?? "",
+        );
+
+        const response = await fetch(url.toString(), { redirect: "manual" });
 
         log.debug("→ Validating issuer rejected the request...");
-        expect(result.success).toBe(false);
+        expect(
+          response.ok,
+          `Expected issuer to reject the request, got HTTP ${response.status}`,
+        ).toBe(false);
 
-        const error = result.error as Oauth2Error;
-        if (!error || error.statusCode !== undefined) {
-          log.debug(
-            "  Error did not carry an HTTP status code (non-Oauth2Error); request was still rejected",
-          );
-          throw new Error(
-            "Error did not carry an HTTP status code (non-Oauth2Error)",
-          );
-        }
-
-        log.debug(`  HTTP status code returned: ${error.statusCode}`);
-        expect(error.statusCode).toBeDefined();
+        log.debug(`  HTTP status code returned: ${response.status}`);
         expect(
           [400, 401, 403],
-          `Expected HTTP 400, 401, or 403, got ${error.statusCode}`,
-        ).toContain(error.statusCode);
+          `Expected HTTP 400, 401, or 403, got ${response.status}`,
+        ).toContain(response.status);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/authorization-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/authorization-validation.issuance.spec.ts
@@ -1,5 +1,8 @@
+/* eslint-disable max-lines-per-function */
+
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { useTestSummary } from "#/helpers/use-test-summary";
+import { Oauth2Error } from "@pagopa/io-wallet-oauth2";
 import { beforeAll, describe, expect, test } from "vitest";
 
 import { loadConfigWithHierarchy } from "@/logic";
@@ -190,5 +193,51 @@ testConfigs.forEach((testConfig) => {
       },
       { timeout: 120e3 },
     );
+
+    // -----------------------------------------------------------------------
+    // CI_059 — Authorization Response HTTP Status Code
+    // -----------------------------------------------------------------------
+
+    test("CI_059: Authorization Response HTTP Status Code | Issuer returns an appropriate HTTP 4xx error status code for an invalid authorization request", async () => {
+      const log = baseLog.withTag("CI_059");
+      const DESCRIPTION =
+        "Issuer returned expected HTTP 4xx status code for invalid authorization request";
+
+      log.start(
+        "Conformance test: Verifying HTTP error status code for invalid authorization request",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Sending authorization request without request_uri (should be rejected)...",
+        );
+        const result = await runAuthStep(testConfig.authorizeStepClass);
+
+        log.debug("→ Validating issuer rejected the request...");
+        expect(result.success).toBe(false);
+
+        const error = result.error as Oauth2Error;
+        if (!error || error.statusCode !== undefined) {
+          log.debug(
+            "  Error did not carry an HTTP status code (non-Oauth2Error); request was still rejected",
+          );
+          throw new Error(
+            "Error did not carry an HTTP status code (non-Oauth2Error)",
+          );
+        }
+
+        log.debug(`  HTTP status code returned: ${error.statusCode}`);
+        expect(error.statusCode).toBeDefined();
+        expect(
+          [400, 401, 403],
+          `Expected HTTP 400, 401, or 403, got ${error.statusCode}`,
+        ).toContain(error.statusCode);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
   });
 });

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -814,6 +814,142 @@ testConfigs.forEach((testConfig) => {
       }
     });
 
+    // -----------------------------------------------------------------------
+    // CI_035 — Wallet Provider Trust Chain Evaluation
+    // -----------------------------------------------------------------------
+
+    test("CI_035: Wallet Provider Trust Chain Evaluation | Credential Issuer successfully evaluates the Wallet Provider trust chain", async () => {
+      const log = baseLog.withTag("CI_035");
+      const DESCRIPTION =
+        "Wallet Provider trust chain was successfully evaluated by the Credential Issuer";
+
+      log.start(
+        "Conformance test: Verifying Wallet Provider trust chain evaluation",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Verifying PAR was accepted as evidence that the trust chain was evaluated...",
+        );
+        expect(
+          pushedAuthorizationRequestResponse.response,
+          "PAR must have been accepted as evidence of successful trust chain evaluation",
+        ).toBeDefined();
+
+        log.debug(
+          "→ Decoding wallet attestation to inspect embedded trust_chain...",
+        );
+        const attestationJwt = await SDJwt.extractJwt(
+          walletAttestationResponse.attestation,
+        );
+        const trustChain = z
+          .array(z.string())
+          .optional()
+          .parse(attestationJwt.header?.trust_chain);
+
+        if (!trustChain || trustChain.length === 0)
+          throw new Error("undefined or empty trust_chain");
+
+        log.debug(
+          `  trust_chain embedded in attestation (${trustChain.length} element(s)) — verifying none is expired`,
+        );
+        const nowSec = Math.floor(Date.now() / 1000);
+        for (const jwt of trustChain) {
+          const jwtPayload = decodeJwt(jwt);
+          if (jwtPayload.exp === undefined)
+            throw new Error("undefined `exp` in trust_chain item");
+
+          expect(
+            jwtPayload.exp,
+            "Trust chain element must not be expired",
+          ).toBeGreaterThan(nowSec);
+        }
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_036 — Federation Metadata Retrieval
+    // -----------------------------------------------------------------------
+
+    test("CI_036: Federation Metadata Retrieval | Credential Issuer retrieves federation metadata from participant endpoints", async () => {
+      const log = baseLog.withTag("CI_036");
+      const DESCRIPTION =
+        "Federation metadata retrieved successfully via .well-known/openid-federation";
+
+      log.start("Conformance test: Verifying federation metadata retrieval");
+
+      let testSuccess = false;
+      try {
+        log.debug("→ Checking metadata was discovered via the federation...");
+        expect(
+          fetchMetadataResponse.response?.discoveredVia,
+          "Metadata must be discovered via the federation (not OID4VCI)",
+        ).toBe("federation");
+
+        log.debug(
+          "→ Verifying entity statement claims contain credential issuer metadata...",
+        );
+        const claims = fetchMetadataResponse.response?.entityStatementClaims;
+        expect(
+          claims?.metadata?.openid_credential_issuer,
+          "Entity statement must include openid_credential_issuer metadata",
+        ).toBeDefined();
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_037 — Wallet Provider Trust Establishment
+    // -----------------------------------------------------------------------
+
+    test("CI_037: Wallet Provider Trust Establishment | Credential Issuer establishes trust in the Wallet Provider via the federation", async () => {
+      const log = baseLog.withTag("CI_037");
+      const DESCRIPTION =
+        "Credential Issuer established trust in the Wallet Provider via the federation";
+
+      log.start(
+        "Conformance test: Verifying Wallet Provider trust establishment via federation",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Verifying PAR was accepted (CI established WP trust before this point)...",
+        );
+        expect(
+          pushedAuthorizationRequestResponse.response?.request_uri,
+          "PAR must have been accepted as evidence of WP trust establishment",
+        ).toBeDefined();
+
+        log.debug("→ Verifying metadata was fetched via the federation...");
+        expect(
+          fetchMetadataResponse.response?.discoveredVia,
+          "Metadata must be discovered via the federation",
+        ).toBe("federation");
+
+        log.debug(
+          "→ Verifying entity statement includes federation_entity metadata...",
+        );
+        const claims = fetchMetadataResponse.response?.entityStatementClaims;
+        expect(
+          claims?.metadata?.federation_entity,
+          "Entity statement must include federation_entity metadata",
+        ).toBeDefined();
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
     // ============================================================================
     // AUTHORIZATION REQUEST TESTS
     // ============================================================================

--- a/tests/conformance/issuance/par-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/par-validation.issuance.spec.ts
@@ -21,6 +21,7 @@ import {
   createPushedAuthorizationRequest,
   CreatePushedAuthorizationRequestOptions,
   fetchPushedAuthorizationResponse,
+  Oauth2Error,
   type PushedAuthorizationRequest,
 } from "@pagopa/io-wallet-oauth2";
 import { IoWalletSdkConfig } from "@pagopa/io-wallet-utils";
@@ -949,6 +950,159 @@ testConfigs.forEach((testConfig) => {
 
         log.debug("→ Validating issuer rejected the request...");
         expect(result.success).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_017 — PAR Scope and Authorization Details Interpretation
+    // -----------------------------------------------------------------------
+
+    test("CI_017: PAR Scope and Authorization Details Interpretation | Issuer accepts a PAR request containing both scope and authorization_details", async () => {
+      const log = baseLog.withTag("CI_017");
+      const DESCRIPTION =
+        "Issuer correctly accepted PAR with both scope and authorization_details";
+
+      log.start(
+        "Conformance test: Verifying PAR with both scope and authorization_details is accepted",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Sending PAR request with scope='openid' alongside authorization_details...",
+        );
+        const result = await runParStep(
+          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
+            scope: "openid",
+          }),
+        );
+
+        log.debug("→ Validating issuer accepted the request...");
+        expect(result.success).toBe(true);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_017a — PAR Authorization Details Precedence
+    // -----------------------------------------------------------------------
+
+    test("CI_017a: PAR Authorization Details Precedence | Issuer honours authorization_details when both scope and authorization_details reference the same credential type", async () => {
+      const log = baseLog.withTag("CI_017a");
+      const DESCRIPTION =
+        "Issuer correctly accepted PAR with matching scope and authorization_details";
+
+      log.start(
+        "Conformance test: Verifying authorization_details precedence over scope for the same credential type",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          `→ Sending PAR with scope='${testConfig.credentialConfigurationId}' matching authorization_details...`,
+        );
+        const result = await runParStep(
+          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
+            scope: testConfig.credentialConfigurationId,
+          }),
+        );
+
+        log.debug(
+          "→ Validating issuer accepted the request (authorization_details honoured)...",
+        );
+        expect(result.success).toBe(true);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_030 — Wallet Provider Federation Membership Validation
+    // -----------------------------------------------------------------------
+
+    test("CI_030: Wallet Provider Federation Membership Validation | Issuer rejects a PAR from a Wallet Provider not present in the federation", async () => {
+      const log = baseLog.withTag("CI_030");
+      const DESCRIPTION =
+        "Issuer correctly rejected PAR from a Wallet Provider not in the federation";
+
+      log.start(
+        "Conformance test: Verifying Wallet Provider federation membership validation",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Creating attestation from a Wallet Provider not registered in the federation...",
+        );
+        const fakeAttestation = await createFakeAttestationResponse();
+
+        log.debug("→ Sending PAR request with unregistered Wallet Provider...");
+        const result = await runParStep(
+          testConfig.pushedAuthorizationRequestStepClass,
+          fakeAttestation,
+        );
+
+        log.debug(
+          "→ Validating issuer rejected the unregistered Wallet Provider...",
+        );
+        expect(result.success).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_045 — PAR Response HTTP Status Code
+    // -----------------------------------------------------------------------
+
+    test("CI_045: PAR Response HTTP Status Code | Issuer returns an appropriate HTTP 4xx error status code for an invalid PAR request", async () => {
+      const log = baseLog.withTag("CI_045");
+      const DESCRIPTION =
+        "Issuer returned expected HTTP 4xx status code for invalid PAR";
+
+      log.start(
+        "Conformance test: Verifying HTTP error status code for invalid PAR request",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug("→ Sending PAR request signed with wrong key...");
+        const result = await runParStep(
+          withSignJwtOverride(
+            testConfig.pushedAuthorizationRequestStepClass,
+            signWithWrongKey(),
+          ),
+        );
+
+        log.debug("→ Validating issuer rejected the request...");
+        expect(result.success).toBe(false);
+
+        const error = result.error as Oauth2Error;
+        if (!error || error.statusCode !== undefined) {
+          log.debug(
+            "  Error did not carry an HTTP status code (non-Oauth2Error); request was still rejected",
+          );
+          throw new Error(
+            "Error did not carry an HTTP status code (non-Oauth2Error)",
+          );
+        }
+
+        log.debug(`  HTTP status code returned: ${error.statusCode}`);
+        expect(
+          [400, 401],
+          `Expected HTTP 400 or 401, got ${error.statusCode}`,
+        ).toContain(error.statusCode);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/par-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/par-validation.issuance.spec.ts
@@ -21,10 +21,12 @@ import {
   createPushedAuthorizationRequest,
   CreatePushedAuthorizationRequestOptions,
   fetchPushedAuthorizationResponse,
-  Oauth2Error,
   type PushedAuthorizationRequest,
 } from "@pagopa/io-wallet-oauth2";
-import { IoWalletSdkConfig } from "@pagopa/io-wallet-utils";
+import {
+  IoWalletSdkConfig,
+  UnexpectedStatusCodeError,
+} from "@pagopa/io-wallet-utils";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import {
@@ -289,6 +291,74 @@ testConfigs.forEach((testConfig) => {
 
         log.debug("→ Validating issuer rejected the tampered request...");
         expect(result.success).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_017 — PAR Scope and Authorization Details Interpretation
+    // -----------------------------------------------------------------------
+
+    test("CI_017: PAR Scope and Authorization Details Interpretation | Issuer accepts a PAR request containing both scope and authorization_details", async () => {
+      const log = baseLog.withTag("CI_017");
+      const DESCRIPTION =
+        "Issuer correctly accepted PAR with both scope and authorization_details";
+
+      log.start(
+        "Conformance test: Verifying PAR with both scope and authorization_details is accepted",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Sending PAR request with scope='openid' alongside authorization_details...",
+        );
+        const result = await runParStep(
+          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
+            scope: "openid",
+          }),
+        );
+
+        log.debug("→ Validating issuer accepted the request...");
+        expect(result.success).toBe(true);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // CI_017a — PAR Authorization Details Precedence
+    // -----------------------------------------------------------------------
+
+    test("CI_017a: PAR Authorization Details Precedence | Issuer honours authorization_details when both scope and authorization_details reference the same credential type", async () => {
+      const log = baseLog.withTag("CI_017a");
+      const DESCRIPTION =
+        "Issuer correctly accepted PAR with matching scope and authorization_details";
+
+      log.start(
+        "Conformance test: Verifying authorization_details precedence over scope for the same credential type",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          `→ Sending PAR with scope='${testConfig.credentialConfigurationId}' matching authorization_details...`,
+        );
+        const result = await runParStep(
+          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
+            scope: testConfig.credentialConfigurationId,
+          }),
+        );
+
+        log.debug(
+          "→ Validating issuer accepted the request (authorization_details honoured)...",
+        );
+        expect(result.success).toBe(true);
 
         testSuccess = true;
       } finally {
@@ -855,6 +925,43 @@ testConfigs.forEach((testConfig) => {
     });
 
     // -----------------------------------------------------------------------
+    // CI_030 — Wallet Provider Federation Membership Validation
+    // -----------------------------------------------------------------------
+
+    test("CI_030: Wallet Provider Federation Membership Validation | Issuer rejects a PAR from a Wallet Provider not present in the federation", async () => {
+      const log = baseLog.withTag("CI_030");
+      const DESCRIPTION =
+        "Issuer correctly rejected PAR from a Wallet Provider not in the federation";
+
+      log.start(
+        "Conformance test: Verifying Wallet Provider federation membership validation",
+      );
+
+      let testSuccess = false;
+      try {
+        log.debug(
+          "→ Creating attestation from a Wallet Provider not registered in the federation...",
+        );
+        const fakeAttestation = await createFakeAttestationResponse();
+
+        log.debug("→ Sending PAR request with unregistered Wallet Provider...");
+        const result = await runParStep(
+          testConfig.pushedAuthorizationRequestStepClass,
+          fakeAttestation,
+        );
+
+        log.debug(
+          "→ Validating issuer rejected the unregistered Wallet Provider...",
+        );
+        expect(result.success).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
     // CI_031 — Wallet Attestation Cryptographic Signature Validation
     // -----------------------------------------------------------------------
 
@@ -958,111 +1065,6 @@ testConfigs.forEach((testConfig) => {
     });
 
     // -----------------------------------------------------------------------
-    // CI_017 — PAR Scope and Authorization Details Interpretation
-    // -----------------------------------------------------------------------
-
-    test("CI_017: PAR Scope and Authorization Details Interpretation | Issuer accepts a PAR request containing both scope and authorization_details", async () => {
-      const log = baseLog.withTag("CI_017");
-      const DESCRIPTION =
-        "Issuer correctly accepted PAR with both scope and authorization_details";
-
-      log.start(
-        "Conformance test: Verifying PAR with both scope and authorization_details is accepted",
-      );
-
-      let testSuccess = false;
-      try {
-        log.debug(
-          "→ Sending PAR request with scope='openid' alongside authorization_details...",
-        );
-        const result = await runParStep(
-          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
-            scope: "openid",
-          }),
-        );
-
-        log.debug("→ Validating issuer accepted the request...");
-        expect(result.success).toBe(true);
-
-        testSuccess = true;
-      } finally {
-        log.testCompleted(DESCRIPTION, testSuccess);
-      }
-    });
-
-    // -----------------------------------------------------------------------
-    // CI_017a — PAR Authorization Details Precedence
-    // -----------------------------------------------------------------------
-
-    test("CI_017a: PAR Authorization Details Precedence | Issuer honours authorization_details when both scope and authorization_details reference the same credential type", async () => {
-      const log = baseLog.withTag("CI_017a");
-      const DESCRIPTION =
-        "Issuer correctly accepted PAR with matching scope and authorization_details";
-
-      log.start(
-        "Conformance test: Verifying authorization_details precedence over scope for the same credential type",
-      );
-
-      let testSuccess = false;
-      try {
-        log.debug(
-          `→ Sending PAR with scope='${testConfig.credentialConfigurationId}' matching authorization_details...`,
-        );
-        const result = await runParStep(
-          withParOverrides(testConfig.pushedAuthorizationRequestStepClass, {
-            scope: testConfig.credentialConfigurationId,
-          }),
-        );
-
-        log.debug(
-          "→ Validating issuer accepted the request (authorization_details honoured)...",
-        );
-        expect(result.success).toBe(true);
-
-        testSuccess = true;
-      } finally {
-        log.testCompleted(DESCRIPTION, testSuccess);
-      }
-    });
-
-    // -----------------------------------------------------------------------
-    // CI_030 — Wallet Provider Federation Membership Validation
-    // -----------------------------------------------------------------------
-
-    test("CI_030: Wallet Provider Federation Membership Validation | Issuer rejects a PAR from a Wallet Provider not present in the federation", async () => {
-      const log = baseLog.withTag("CI_030");
-      const DESCRIPTION =
-        "Issuer correctly rejected PAR from a Wallet Provider not in the federation";
-
-      log.start(
-        "Conformance test: Verifying Wallet Provider federation membership validation",
-      );
-
-      let testSuccess = false;
-      try {
-        log.debug(
-          "→ Creating attestation from a Wallet Provider not registered in the federation...",
-        );
-        const fakeAttestation = await createFakeAttestationResponse();
-
-        log.debug("→ Sending PAR request with unregistered Wallet Provider...");
-        const result = await runParStep(
-          testConfig.pushedAuthorizationRequestStepClass,
-          fakeAttestation,
-        );
-
-        log.debug(
-          "→ Validating issuer rejected the unregistered Wallet Provider...",
-        );
-        expect(result.success).toBe(false);
-
-        testSuccess = true;
-      } finally {
-        log.testCompleted(DESCRIPTION, testSuccess);
-      }
-    });
-
-    // -----------------------------------------------------------------------
     // CI_045 — PAR Response HTTP Status Code
     // -----------------------------------------------------------------------
 
@@ -1088,13 +1090,13 @@ testConfigs.forEach((testConfig) => {
         log.debug("→ Validating issuer rejected the request...");
         expect(result.success).toBe(false);
 
-        const error = result.error as Oauth2Error;
-        if (!error || error.statusCode !== undefined) {
+        const error = result.error as UnexpectedStatusCodeError;
+        if (!error || error.statusCode === undefined) {
           log.debug(
-            "  Error did not carry an HTTP status code (non-Oauth2Error); request was still rejected",
+            "  Error did not carry an HTTP status code (non-UnexpectedStatusCodeError); request was still rejected",
           );
           throw new Error(
-            "Error did not carry an HTTP status code (non-Oauth2Error)",
+            "Error did not carry an HTTP status code (non-UnexpectedStatusCodeError)",
           );
         }
 

--- a/tests/docs/TEST-EXECUTION-REFERENCE.md
+++ b/tests/docs/TEST-EXECUTION-REFERENCE.md
@@ -22,6 +22,12 @@ The issuance flow validates credential issuance conformance according to [Creden
 
 - **CI_009**: Inspects the `metadata` object inside the Entity Configuration and verifies that the `openid_credential_verifier` key is present. This sub-object is required when the Credential Issuer acts as a verifier during user authentication (i.e., when it requests a PID presentation from the Wallet Instance via OpenID4VP). Fails if the key is absent.
 
+- **CI_035**: Verifies that the Credential Issuer successfully evaluates the Wallet Provider's trust chain. It checks that the PAR request was accepted (indicating trust was established) and that the `trust_chain` embedded in the wallet attestation contains only non-expired JWTs.
+
+- **CI_036**: Verifies that the Credential Issuer retrieves federation metadata via the `.well-known/openid-federation` endpoint. Confirms that metadata was discovered via the federation and that the entity statement contains `openid_credential_issuer` metadata.
+
+- **CI_037**: Verifies that the Credential Issuer establishes trust in the Wallet Provider via the federation. Confirms that PAR was accepted and that the fetched entity statement includes `federation_entity` metadata.
+
 #### Credential Offer Tests
 
 - **CI_010**: Verifies that the `credential_offer_uri` (or the embedded `credential_offer`) has a valid structure. It checks that the URI starts with a recognized scheme (`openid-credential-offer://`, `haip-vci://`, or `https://`) and that the JSON offer can be successfully retrieved and parsed.
@@ -43,6 +49,10 @@ These are negative tests: each sends a deliberately malformed PAR request and ve
 - **CI_015c**: Sends a PAR Request Object where the `kid` header is set to `"wrong-kid-that-does-not-match"` even though the JWT is signed with the correct wallet key. Verifies that the issuer checks the `kid` header value against the key reference in the Wallet Attestation and rejects a mismatched identifier.
 
 - **CI_015d**: Signs a valid PAR Request Object, then decodes the payload, modifies the `aud` claim to `"https://tampered.example.com"`, re-encodes it, and reassembles the token (original signature is now invalid for the modified payload). Verifies that the issuer detects payload tampering through cryptographic signature verification.
+
+- **CI_017**: Sends a PAR request containing both `scope` and `authorization_details`. Verifies that the issuer correctly accepts the request, confirming it can interpret both parameters simultaneously.
+
+- **CI_017a**: Sends a PAR request where both `scope` and `authorization_details` reference the same credential type. Verifies that the issuer accepts the request, implying that `authorization_details` is honoured as the primary source of credential configuration.
 
 - **CI_019**: Sends a PAR Request Object signed with HMAC-SHA256 (`HS256`), a symmetric algorithm. Verifies that the issuer enforces the requirement for asymmetric algorithms only and rejects the request.
 
@@ -70,6 +80,8 @@ These are negative tests: each sends a deliberately malformed PAR request and ve
 
 - **CI_028c**: Builds a PoP JWT with `iat` 11 minutes in the past and `exp` 10 minutes in the past, making it already expired at request time. Verifies that the issuer validates the PoP expiration time and rejects an expired PoP.
 
+- **CI_030**: Sends a PAR request with a Wallet Attestation from a Wallet Provider that is not registered in the trust federation. Verifies that the issuer rejects the request, confirming it validates the Wallet Provider's membership in the federation.
+
 - **CI_031**: Sends a PAR request with a wallet attestation that has been tampered with (e.g., modified `sub` claim). Verifies that the issuer detects the invalid cryptographic signature of the attestation and rejects the request.
 
 - **CI_032**: Sends a PAR request with a wallet attestation that has already expired. Verifies that the issuer validates the attestation's expiration time (`exp` claim) and rejects the expired token.
@@ -94,6 +106,8 @@ These are positive checks run against the response of a successful PAR request.
 
 - **CI_044b**: Reads the `expires_in` field from the PAR response and asserts that it is a positive number. This value tells the wallet how many seconds the `request_uri` remains valid before it must start a new PAR.
 
+- **CI_045**: Sends an invalid PAR request (e.g., signed with the wrong key) and verifies that the issuer returns an appropriate HTTP 4xx status code (e.g., 400 or 401). This ensures the issuer provides standard OAuth 2.0 error signaling at the HTTP layer.
+
 - **CI_029**: Verifies that the Credential Issuer successfully resolves the Wallet Instance's trust chain and accepts a PAR request from a trusted wallet. The test checks that the PAR step returned a defined response with no error. It also decodes the wallet attestation JWT header: if a `trust_chain` array is embedded directly, the issuer resolved trust from there; otherwise, trust is resolved through the federation API endpoints (`.well-known/openid-federation`). Either path is accepted; what matters is that the issuer validated the attestation end-to-end and returned a successful PAR response.
 
 #### Authorization Request Validation Tests
@@ -105,6 +119,8 @@ These are positive checks run against the response of a successful PAR request.
 - **CI_049**: Verifies PAR–authorization correlation. Checks that the PAR response contained a `request_uri` matching the URN pattern `urn:ietf:params:oauth:request_uri:…`, and that the subsequent authorization step succeeded and returned an authorization `code`. If the issuer had not correctly associated the PAR session with the authorization request, the authorization would have failed.
 
 - **CI_050**: Sends an authorization request without a `request_uri` parameter (empty string). Verifies that the issuer rejects the request, enforcing the PAR-only flow where authorization requests must reference a previously submitted PAR via `request_uri`.
+
+- **CI_059**: Sends an invalid authorization request (e.g., missing `request_uri`) and verifies that the issuer returns an appropriate HTTP 4xx status code (e.g., 400, 401, or 403). This ensures consistent error reporting for authorization requests.
 
 #### Authorization Tests
 


### PR DESCRIPTION
Introduces new conformance tests to verify:
- PAR scope and authorization_details interpretation (CI_017, CI_017a)
- Wallet Provider federation membership and trust establishment (CI_030, CI_035, CI_036, CI_037)
- Proper HTTP error signaling for PAR and Authorization endpoints (CI_045, CI_059)

These tests ensure robust validation of entity requests and authorization parameters, supporting the objective of allowing additional filters for entity requests.

JIRA Ticket: WLEO-1264