### PR TITLE
feat: add token validation and c_nonce conformance tests (WLEO-1265)

### DIFF
--- a/tests/conformance/issuance/token-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/token-validation.issuance.spec.ts
@@ -8,7 +8,10 @@ import {
   createTokenDPoP,
   Jwk,
 } from "@pagopa/io-wallet-oauth2";
-import { IoWalletSdkConfig } from "@pagopa/io-wallet-utils";
+import {
+  IoWalletSdkConfig,
+  UnexpectedStatusCodeError,
+} from "@pagopa/io-wallet-utils";
 import { beforeAll, describe, expect, test } from "vitest";
 
 import {
@@ -20,11 +23,12 @@ import {
 } from "@/logic";
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
 import {
+  CredentialRequestResponse,
   FetchMetadataStepResponse,
   TokenRequestDefaultStep,
   TokenRequestResponse,
 } from "@/step/issuance";
-import { AttestationResponse } from "@/types";
+import { AttestationResponse, RunThroughTokenContext } from "@/types";
 
 // ---------------------------------------------------------------------------
 // Module-level test registration
@@ -231,6 +235,39 @@ testConfigs.forEach((testConfig) => {
     });
 
     // -----------------------------------------------------------------------
+    // CI_067 — Token Response HTTP Status Code
+    // -----------------------------------------------------------------------
+
+    test("CI_067: Token Response HTTP Status Code | Token endpoint returns HTTP 400 for invalid requests", async () => {
+      const log = baseLog.withTag("CI_067");
+      const DESCRIPTION =
+        "Token endpoint returns HTTP 400 for invalid requests";
+      log.start(
+        "Conformance test: Verifying token endpoint HTTP status code for invalid requests",
+      );
+
+      let testSuccess = false;
+      try {
+        const result = await runTokenStep(testConfig.tokenRequestStepClass, {
+          code: "invalid-code-for-status-check",
+          code_verifier: codeVerifier,
+          grant_type: "authorization_code",
+          redirect_uri: redirectUri,
+        });
+
+        expect(result.success).toBe(false);
+        const tokenError = result.error as UnexpectedStatusCodeError;
+        expect(
+          tokenError.statusCode,
+          "Token endpoint must return HTTP 400 for invalid requests",
+        ).toBe(400);
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    // -----------------------------------------------------------------------
     // CI_061 — Authorization Code Validity
     // -----------------------------------------------------------------------
 
@@ -269,6 +306,262 @@ testConfigs.forEach((testConfig) => {
           });
           expect(result2.success).toBe(false);
           log.info("✅ Reused code rejected");
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // CI_065 — Optional Refresh Token Provision
+    // -----------------------------------------------------------------------
+
+    test(
+      "CI_065: Refresh Token | If a refresh_token is returned it must have a valid JWT format",
+      { timeout: 6e3 },
+      async () => {
+        const log = baseLog.withTag("CI_065");
+        const DESCRIPTION = "Refresh token, when present, has valid JWT format";
+        log.start("Conformance test: Verifying optional refresh token format");
+
+        let testSuccess = false;
+        try {
+          const {
+            code,
+            codeVerifier: freshCodeVerifier,
+            redirectUri: freshRedirectUri,
+          } = await runAndValidateAuthorize(orchestrator);
+
+          log.info(
+            "→ Performing successful token request to check for refresh_token...",
+          );
+          const tokenResult = await runTokenStep(
+            testConfig.tokenRequestStepClass,
+            {
+              code,
+              code_verifier: freshCodeVerifier,
+              grant_type: "authorization_code",
+              redirect_uri: freshRedirectUri,
+            },
+          );
+          expect(tokenResult.success).toBe(true);
+
+          const refreshToken = tokenResult.response?.refresh_token;
+          if (!refreshToken) {
+            log.info(
+              "ℹ️  Refresh token not issued (optional per spec — test passes)",
+            );
+            testSuccess = true;
+            return;
+          }
+
+          log.info("  Refresh token present, validating JWT format...");
+          const parts = refreshToken.split(".");
+          expect(
+            parts.length,
+            "Refresh token must be a JWT with 3 dot-separated parts",
+          ).toBe(3);
+          for (const part of parts) {
+            expect(
+              part.length,
+              "Each JWT segment must be non-empty",
+            ).toBeGreaterThan(0);
+            expect(
+              /^[A-Za-z0-9_-]+$/.test(part),
+              "Each JWT segment must be base64url-encoded",
+            ).toBe(true);
+          }
+          log.info("✅ Refresh token has valid JWT format");
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // CI_070 — C_nonce Reusability and Renewal
+    // -----------------------------------------------------------------------
+
+    test(
+      "CI_070: C_nonce | Same c_nonce is reusable until the server provides a new one",
+      { timeout: 20e3 },
+      async () => {
+        const log = baseLog.withTag("CI_070");
+        const DESCRIPTION =
+          "C_nonce reusability and renewal behaviour verified";
+        log.start(
+          "Conformance test: Verifying c_nonce reusability and renewal",
+        );
+
+        let testSuccess = false;
+        try {
+          log.info("→ Running full flow to obtain token context...");
+          const tokenCtx: RunThroughTokenContext =
+            await orchestrator.runThroughToken();
+          const entityStatementClaims =
+            tokenCtx.fetchMetadataResponse.response?.entityStatementClaims;
+
+          const rawNonceEndpoint =
+            entityStatementClaims?.metadata?.openid_credential_issuer
+              ?.nonce_endpoint;
+          if (!rawNonceEndpoint)
+            throw new Error("Issuer metadata does not contain nonce_endpoint");
+          const nonceEndpoint: string = rawNonceEndpoint;
+
+          const rawCredentialEndpoint =
+            entityStatementClaims?.metadata?.openid_credential_issuer
+              ?.credential_endpoint;
+          if (!rawCredentialEndpoint)
+            throw new Error(
+              "Issuer metadata does not contain credential_endpoint",
+            );
+          const credentialEndpoint: string = rawCredentialEndpoint;
+
+          const rawAccessToken = tokenCtx.tokenResponse.response?.access_token;
+          if (!rawAccessToken)
+            throw new Error("Token step did not return access_token");
+          const accessToken: string = rawAccessToken;
+
+          const config = loadConfigWithHierarchy();
+
+          async function fetchNonce(): Promise<string> {
+            const nonceStep = new testConfig.nonceRequestStepClass(
+              config,
+              createQuietLogger(),
+            );
+            const nonceResp = await nonceStep.run({ nonceEndpoint });
+            const nonce = nonceResp.response?.nonce as
+              | undefined
+              | { c_nonce: string };
+            if (!nonce?.c_nonce)
+              throw new Error("Failed to obtain c_nonce from nonce endpoint");
+            return nonce.c_nonce;
+          }
+
+          async function runCredentialWithNonce(
+            nonce: string,
+          ): Promise<CredentialRequestResponse> {
+            const step = new testConfig.credentialRequestStepClass(
+              config,
+              createQuietLogger(),
+            );
+            return step.run({
+              accessToken,
+              baseUrl: tokenCtx.credentialIssuer,
+              clientId:
+                tokenCtx.walletAttestationResponse.unitKey.publicKey.kid,
+              credentialIdentifier: testConfig.credentialConfigurationId,
+              credentialRequestEndpoint: credentialEndpoint,
+              dPoPKey: tokenCtx.dPoPKey,
+              nonce,
+              walletAttestation: tokenCtx.walletAttestationResponse,
+            });
+          }
+
+          log.info("→ Fetching first c_nonce...");
+          const nonce1 = await fetchNonce();
+          log.debug(`  nonce1 length: ${nonce1.length}`);
+
+          log.info("→ First credential request with nonce1...");
+          const result1 = await runCredentialWithNonce(nonce1);
+          expect(
+            result1.success,
+            "First credential request with fresh c_nonce must succeed",
+          ).toBe(true);
+          log.info("✅ First credential request succeeded");
+
+          log.info("→ Second credential request reusing nonce1...");
+          const result2 = await runCredentialWithNonce(nonce1);
+          if (result2.success) {
+            log.info(
+              "ℹ️  Server allows c_nonce reuse (nonce remains valid after first use)",
+            );
+          } else {
+            log.info(
+              "ℹ️  Server enforces single-use c_nonce (nonce invalidated after first use)",
+            );
+          }
+
+          log.info("→ Fetching second c_nonce...");
+          const nonce2 = await fetchNonce();
+          log.debug(`  nonce2 length: ${nonce2.length}`);
+          expect(
+            nonce2,
+            "Server must generate distinct c_nonce values on each request",
+          ).not.toBe(nonce1);
+
+          log.info("→ Credential request with renewed nonce2...");
+          const result3 = await runCredentialWithNonce(nonce2);
+          expect(
+            result3.success,
+            "Credential request with a fresh c_nonce must succeed",
+          ).toBe(true);
+          log.info("✅ Credential request with renewed c_nonce succeeded");
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // CI_098 — TLS-Protected Refresh Token Transmission
+    // -----------------------------------------------------------------------
+
+    test(
+      "CI_098: TLS | Refresh token is transmitted only over a TLS-protected channel",
+      { timeout: 6e3 },
+      async () => {
+        const log = baseLog.withTag("CI_098");
+        const DESCRIPTION = "Token endpoint is TLS-protected (HTTPS)";
+        log.start(
+          "Conformance test: Verifying TLS protection of token endpoint",
+        );
+
+        let testSuccess = false;
+        try {
+          const entityStatementClaims =
+            fetchMetadataResponse.response?.entityStatementClaims;
+          const tokenEndpoint =
+            entityStatementClaims?.metadata?.oauth_authorization_server
+              ?.token_endpoint;
+
+          log.debug(`  token_endpoint: ${tokenEndpoint}`);
+          expect(
+            tokenEndpoint,
+            "Token endpoint must use HTTPS to protect refresh token transmission",
+          ).toMatch(/^https:\/\//);
+
+          const {
+            code,
+            codeVerifier: freshCodeVerifier,
+            redirectUri: freshRedirectUri,
+          } = await runAndValidateAuthorize(orchestrator);
+          const tokenResult = await runTokenStep(
+            testConfig.tokenRequestStepClass,
+            {
+              code,
+              code_verifier: freshCodeVerifier,
+              grant_type: "authorization_code",
+              redirect_uri: freshRedirectUri,
+            },
+          );
+          expect(tokenResult.success).toBe(true);
+
+          if (tokenResult.response?.refresh_token) {
+            log.info(
+              "  Refresh token received over TLS-protected HTTPS endpoint ✅",
+            );
+          } else {
+            log.info(
+              "  No refresh token issued; token endpoint TLS protection confirmed ✅",
+            );
+          }
 
           testSuccess = true;
         } finally {

--- a/tests/conformance/issuance/token-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/token-validation.issuance.spec.ts
@@ -256,6 +256,7 @@ testConfigs.forEach((testConfig) => {
         });
 
         expect(result.success).toBe(false);
+        expect(result.error).toBeInstanceOf(UnexpectedStatusCodeError);
         const tokenError = result.error as UnexpectedStatusCodeError;
         expect(
           tokenError.statusCode,
@@ -387,7 +388,7 @@ testConfigs.forEach((testConfig) => {
     // -----------------------------------------------------------------------
 
     test(
-      "CI_070: C_nonce | Same c_nonce is reusable until the server provides a new one",
+      "CI_070: C_nonce | Server issues distinct nonces and credential requests with fresh c_nonce must succeed",
       { timeout: 20e3 },
       async () => {
         const log = baseLog.withTag("CI_070");
@@ -400,8 +401,11 @@ testConfigs.forEach((testConfig) => {
         let testSuccess = false;
         try {
           log.info("→ Running full flow to obtain token context...");
+          const freshOrchestrator = new WalletIssuanceOrchestratorFlow(
+            testConfig,
+          );
           const tokenCtx: RunThroughTokenContext =
-            await orchestrator.runThroughToken();
+            await freshOrchestrator.runThroughToken();
           const entityStatementClaims =
             tokenCtx.fetchMetadataResponse.response?.entityStatementClaims;
 


### PR DESCRIPTION
Add new conformance test cases to verify token issuance and nonce management:
- CI_067: Check HTTP 400 status for invalid token requests.
- CI_065: Verify JWT format of optional refresh tokens.
- CI_070: Validate c_nonce reusability and renewal logic at the credential endpoint.
- CI_098: Confirm token endpoint uses TLS (HTTPS).

JIRA Ticket: WLEO-1265