### PR TITLE
Add PID Provider Authorization Testing

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -40,6 +40,10 @@ url = https://issuer.example
 # The credential will be saved in the path specified in wallet->credentials_storage_path
 save_credential = false
 
+# Port on which the local OAuth2 callback server listens.
+# The redirect_uri used in PAR and token requests is http://localhost:{callback_port}/cb
+callback_port = 4000
+
 # List of credentialConfigurationIds to test (used by test suite)
 # Example:
 credential_types[] = dc_sd_jwt_EuropeanDisabilityCard

--- a/src/functions/load-attestation.ts
+++ b/src/functions/load-attestation.ts
@@ -101,6 +101,7 @@ const buildAttestationOptions = async (
   const commonOptions = {
     callbacks,
     dpopJwkPublic: unitPublicKey,
+    expiresAt: new Date(Date.now() + 3600 * 1000), // 1 hour expiration
     issuer: wpBaseUrl,
     walletLink: `${wpBaseUrl}/wallet`,
     walletName: wallet.wallet_name,
@@ -127,7 +128,7 @@ const buildAttestationOptions = async (
       );
       const attestationOptions: WalletAttestationOptions = {
         ...commonOptions,
-        signer: { ...signerBase, method: "x5c", trustChain, x5c },
+        signer: { ...signerBase, method: "x5c", x5c },
       };
       return attestationOptions;
     }

--- a/src/logic/callback-server.ts
+++ b/src/logic/callback-server.ts
@@ -1,0 +1,78 @@
+import type { AuthorizationResponse } from "@pagopa/io-wallet-oid4vci";
+
+import * as http from "node:http";
+import { URL } from "node:url";
+
+import { CALLBACK_PATH } from "./constants";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Starts a temporary HTTP server that listens for the OAuth2 authorization
+ * callback on `http://localhost:{port}{CALLBACK_PATH}`.
+ *
+ * Resolves when the authorization server redirects the browser to the
+ * callback endpoint with `code`, `iss`, and `state` query parameters.
+ *
+ * Rejects after `timeoutMs` milliseconds if no valid callback is received.
+ */
+export function startCallbackServer(
+  port: number,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<AuthorizationResponse> {
+  return new Promise<AuthorizationResponse>((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const reqUrl = new URL(req.url ?? "", `http://localhost:${port}`);
+
+      if (reqUrl.pathname !== CALLBACK_PATH) {
+        res.writeHead(404).end("Not found");
+        return;
+      }
+
+      const code = reqUrl.searchParams.get("code");
+      const iss = reqUrl.searchParams.get("iss");
+      const state = reqUrl.searchParams.get("state");
+
+      if (!code || !iss || !state) {
+        res
+          .writeHead(400)
+          .end(
+            "Missing required parameters: code, iss, and state are all required.",
+          );
+        return;
+      }
+
+      res
+        .writeHead(200, { "Content-Type": "text/html" })
+        .end(
+          "<html><body><h1>Authorization successful</h1><p>You can close this tab and return to the terminal.</p></body></html>",
+        );
+
+      cleanup();
+      resolve({ code, iss, state });
+    });
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Callback server timed out after ${timeoutMs / 1000}s waiting for authorization callback on port ${port}`,
+        ),
+      );
+    }, timeoutMs);
+
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      server.close();
+    };
+
+    server.on("error", (err) => {
+      cleanup();
+      reject(
+        new Error(`Callback server error on port ${port}: ${err.message}`),
+      );
+    });
+
+    server.listen(port, "127.0.0.1");
+  });
+}

--- a/src/logic/constants.ts
+++ b/src/logic/constants.ts
@@ -1,1 +1,12 @@
+/** @deprecated Use {@link getCallbackRedirectUri} with a config-driven port instead. */
 export const REDIRECT_URI = "https://client.example.org/cb";
+
+export const CALLBACK_PATH = "/cb";
+
+/**
+ * Returns the local redirect URI used by the OAuth2 authorization callback
+ * server. Must match the `redirect_uri` registered in the PAR step and used
+ * in the token request.
+ */
+export const getCallbackRedirectUri = (port: number): string =>
+  `http://localhost:${port}${CALLBACK_PATH}`;

--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -1,3 +1,4 @@
+export * from "./callback-server";
 export * from "./config-loader";
 export * from "./entrypoint";
 export * from "./federation-metadata";

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -25,7 +25,7 @@ import {
 import { resolvePackageAssetPath } from "./runtime-paths";
 
 export const CLOCK_SKEW_TOLERANCE_MS = 30_000;
-export const VALIDITY_MS = 1000 * 60 * 60 * 24 * 365;
+export const VALIDITY_MS = 1000 * 60 * 60 * 24 * 365 * 2; // 2 years
 
 // Re-export config loading functions
 export {

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -2,7 +2,7 @@ import * as x509 from "@peculiar/x509";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-import { getLocalWpBaseUrl } from "@/servers/wp-server";
+import { getLocalWpBaseUrl, LOCAL_WP_HOST } from "@/servers/wp-server";
 import { Config, KeyPair } from "@/types";
 
 import { createKeys } from "./jwk";
@@ -12,7 +12,7 @@ import {
   hasX509CertificateExpired,
   pemToBase64Der,
 } from "./pem";
-import { ensureDir, loadJwks } from "./utils";
+import { buildCertPath, buildJwksPath, ensureDir, loadJwks } from "./utils";
 
 /** Filenames for persisted intermediate artefacts */
 const CA_INTERMEDIATE_CERT = "ca_intermediate_cert";
@@ -53,67 +53,69 @@ export async function loadWalletProviderCertificate(
   ensureDir(caCertPath);
   ensureDir(backupPath);
 
-  const ca1Path = path.resolve(path.join(caCertPath, CA_INTERMEDIATE_CERT));
-  const ca2Path = path.resolve(path.join(backupPath, WALLET_PROVIDER_CERT));
+  const wpIntermediateCertPath = path.resolve(path.join(caCertPath, CA_INTERMEDIATE_CERT));
+  const wpCertPath = path.resolve(path.join(backupPath, WALLET_PROVIDER_CERT));
+  const taCertPath = path.resolve(path.join(backupPath, buildCertPath("trust_anchor")));
 
   // ── Try loading the cached chain ──────────────────────────────────────
-  const cachedCA1 = loadCachedCert(ca1Path);
-  const cachedCA2 = loadCachedCert(ca2Path);
+  const wpIntermediateCachedCert = loadCachedCert(wpIntermediateCertPath);
+  const wpCachedCert = loadCachedCert(wpCertPath);
+  const taCachedCert = loadCachedCert(taCertPath);
 
-  if (cachedCA1 && cachedCA2 && hasSanExtension(cachedCA2)) {
-    return [cachedCA2, cachedCA1];
+  if (wpCachedCert && hasSanExtension(wpCachedCert) && wpIntermediateCachedCert && taCachedCert) {
+    return [wpCachedCert, wpIntermediateCachedCert, taCachedCert];
   }
 
   // ── Invalidate stale artefacts ────────────────────────────────────────
-  for (const p of [ca1Path, ca2Path]) {
+  for (const p of [wpIntermediateCertPath, wpCertPath]) {
     if (existsSync(p)) rmSync(p);
   }
 
   // ── Load Trust Anchor key pair ────────────────────────────────────────
   const taKeyPair = await loadJwks(
     trust.federation_trust_anchors_jwks_path,
-    "trust_anchor_jwks",
+    buildJwksPath("trust_anchor"),
   );
 
   // ── Generate intermediate key pair (KY1) ──────────────────────────────
-  const intermediateKeyPair = await createKeys();
+  const wpIntermediateKeyPair = await createKeys();
 
-  // ── CA1: signed by TA, attests KY1 (isCA = true) ─────────────────────
+  // ── wpIntermediateCert: signed by TA, attests KY1 (isCA = true) ─────────────────────
   const taSubject = trust.certificate_subject;
-  const intermediateSubject = "CN=WalletProvider Intermediate CA";
+  const wpSubject = `CN=${LOCAL_WP_HOST}`;
 
-  const ca1Cert = await createSignedCertificate(
+  const wpIntermediateCert = await createSignedCertificate(
     taKeyPair,
     taSubject,
-    intermediateKeyPair,
-    intermediateSubject,
+    wpIntermediateKeyPair,
+    wpSubject,
     true,
   );
 
-  writeFileSync(ca1Path, ca1Cert.toString("pem"));
-  const ca1Base64 = Buffer.from(ca1Cert.rawData).toString("base64");
+  writeFileSync(wpIntermediateCertPath, wpIntermediateCert.toString("pem"));
+  const wpIntermediateCertBase64 = Buffer.from(wpIntermediateCert.rawData).toString("base64");
 
   // ── CA2: signed by KY1, attests providerKeyPair / KY2 (leaf) ─────────
-  const providerDomain = getLocalWpBaseUrl(wallet.port);
+  const wpBaseUrl = getLocalWpBaseUrl(wallet.port);
 
-  const ca2Cert = await createSignedCertificate(
-    intermediateKeyPair,
-    intermediateSubject,
+  const wpCert = await createSignedCertificate(
+    wpIntermediateKeyPair,
+    wpSubject,
     providerKeyPair,
-    `CN=${providerDomain}`,
+    wpSubject,
     false,
     [
       new x509.SubjectAlternativeNameExtension(
-        [{ type: "dns", value: providerDomain }],
+        [{ type: "dns", value: LOCAL_WP_HOST }, { type: "url", value: wpBaseUrl }],
         false,
       ),
     ],
   );
 
-  writeFileSync(ca2Path, ca2Cert.toString("pem"));
-  const ca2Base64 = Buffer.from(ca2Cert.rawData).toString("base64");
+  writeFileSync(wpCertPath, wpCert.toString("pem"));
+  const wpCertBase64 = Buffer.from(wpCert.rawData).toString("base64");
 
-  return [ca2Base64, ca1Base64];
+  return [wpCertBase64, wpIntermediateCertBase64];
 }
 
 /**

--- a/src/logic/wallet-provider.ts
+++ b/src/logic/wallet-provider.ts
@@ -53,16 +53,25 @@ export async function loadWalletProviderCertificate(
   ensureDir(caCertPath);
   ensureDir(backupPath);
 
-  const wpIntermediateCertPath = path.resolve(path.join(caCertPath, CA_INTERMEDIATE_CERT));
+  const wpIntermediateCertPath = path.resolve(
+    path.join(caCertPath, CA_INTERMEDIATE_CERT),
+  );
   const wpCertPath = path.resolve(path.join(backupPath, WALLET_PROVIDER_CERT));
-  const taCertPath = path.resolve(path.join(backupPath, buildCertPath("trust_anchor")));
+  const taCertPath = path.resolve(
+    path.join(backupPath, buildCertPath("trust_anchor")),
+  );
 
   // ── Try loading the cached chain ──────────────────────────────────────
   const wpIntermediateCachedCert = loadCachedCert(wpIntermediateCertPath);
   const wpCachedCert = loadCachedCert(wpCertPath);
   const taCachedCert = loadCachedCert(taCertPath);
 
-  if (wpCachedCert && hasSanExtension(wpCachedCert) && wpIntermediateCachedCert && taCachedCert) {
+  if (
+    wpCachedCert &&
+    hasSanExtension(wpCachedCert) &&
+    wpIntermediateCachedCert &&
+    taCachedCert
+  ) {
     return [wpCachedCert, wpIntermediateCachedCert, taCachedCert];
   }
 
@@ -93,7 +102,9 @@ export async function loadWalletProviderCertificate(
   );
 
   writeFileSync(wpIntermediateCertPath, wpIntermediateCert.toString("pem"));
-  const wpIntermediateCertBase64 = Buffer.from(wpIntermediateCert.rawData).toString("base64");
+  const wpIntermediateCertBase64 = Buffer.from(
+    wpIntermediateCert.rawData,
+  ).toString("base64");
 
   // ── CA2: signed by KY1, attests providerKeyPair / KY2 (leaf) ─────────
   const wpBaseUrl = getLocalWpBaseUrl(wallet.port);
@@ -106,7 +117,10 @@ export async function loadWalletProviderCertificate(
     false,
     [
       new x509.SubjectAlternativeNameExtension(
-        [{ type: "dns", value: LOCAL_WP_HOST }, { type: "url", value: wpBaseUrl }],
+        [
+          { type: "dns", value: LOCAL_WP_HOST },
+          { type: "url", value: wpBaseUrl },
+        ],
         false,
       ),
     ],

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -5,9 +5,8 @@ import {
 } from "@pagopa/io-wallet-oauth2";
 import { resolveCredentialOffer } from "@pagopa/io-wallet-oid4vci";
 import { IoWalletSdkConfig } from "@pagopa/io-wallet-utils";
-import { randomUUID } from "node:crypto";
 
-import { loadAttestation, loadCredentialsForPresentation } from "@/functions";
+import { loadAttestation } from "@/functions";
 import {
   createLogger,
   loadConfigWithHierarchy,
@@ -15,7 +14,7 @@ import {
   saveCredentialToDisk,
   signJwtCallback,
 } from "@/logic";
-import { REDIRECT_URI } from "@/logic/constants";
+import { getCallbackRedirectUri } from "@/logic/constants";
 import {
   CredentialConfigurationError,
   IssuerMetadataError,
@@ -542,7 +541,7 @@ export class WalletIssuanceOrchestratorFlow {
       code: authorizeResponse.response.authorizeResponse.code,
       code_verifier,
       grant_type: "authorization_code",
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: getCallbackRedirectUri(this.config.issuance.callback_port),
     };
 
     const tokenResponse = await this.tokenRequestStep.run({

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -221,9 +221,9 @@ export class WalletIssuanceOrchestratorFlow {
 
       const credentialResponse = await this.credentialRequestStep.run({
         accessToken,
-        baseUrl: credentialIssuer,
         clientId: walletAttestationResponse.unitKey.publicKey.kid,
         credentialIdentifier: this.issuanceConfig.credentialConfigurationId,
+        credentialIssuer: credentialIssuer,
         credentialRequestEndpoint:
           entityStatementClaims.metadata?.openid_credential_issuer
             ?.credential_endpoint,

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -5,8 +5,9 @@ import {
 } from "@pagopa/io-wallet-oauth2";
 import { resolveCredentialOffer } from "@pagopa/io-wallet-oid4vci";
 import { IoWalletSdkConfig } from "@pagopa/io-wallet-utils";
+import { randomUUID } from "node:crypto";
 
-import { loadAttestation } from "@/functions";
+import { loadAttestation, loadCredentialsForPresentation } from "@/functions";
 import {
   createLogger,
   loadConfigWithHierarchy,
@@ -328,6 +329,7 @@ export class WalletIssuanceOrchestratorFlow {
           ?.authorization_endpoint,
       baseUrl: credentialIssuer,
       clientId: walletAttestationResponse.unitKey.publicKey.kid,
+      credentialIdentifier: this.issuanceConfig.credentialConfigurationId,
       credentials,
       requestUri: pushedAuthorizationRequestResponse.response?.request_uri,
       rpMetadata: entityStatementClaims.metadata?.openid_credential_verifier,
@@ -524,10 +526,6 @@ export class WalletIssuanceOrchestratorFlow {
 
     const code = authorizeResponse.response.authorizeResponse?.code;
     if (!code) throw new StepOutputError("AUTHORIZE", "code");
-
-    const { requestObject } = authorizeResponse.response;
-    if (!requestObject)
-      throw new StepOutputError("AUTHORIZE", "request_object");
 
     const code_verifier =
       pushedAuthorizationRequestResponse.response?.codeVerifier;

--- a/src/step/issuance/authorize-step.ts
+++ b/src/step/issuance/authorize-step.ts
@@ -4,16 +4,20 @@ import {
 } from "@pagopa/io-wallet-oid4vci";
 import {
   createAuthorizationResponse,
-  type CreateAuthorizationResponseVersionedOptions,
+  CreateAuthorizationResponseVersionedOptions,
   parseAuthorizeRequest,
   ParsedAuthorizeRequestResult,
 } from "@pagopa/io-wallet-oid4vp";
 import { ItWalletCredentialVerifierMetadata } from "@pagopa/io-wallet-oid-federation";
 import { DcqlQuery } from "dcql";
+import { exec } from "node:child_process";
+import { platform } from "node:os";
 
-import { buildVpToken } from "@/logic";
+import { startCallbackServer } from "@/logic/callback-server";
+import { getCallbackRedirectUri } from "@/logic/constants";
 import { getEncryptJweCallback, verifyJwt } from "@/logic/jwt";
 import { fetchWithRetries, partialCallbacks } from "@/logic/utils";
+import { buildVpToken } from "@/logic/vpToken";
 import { AttestationResponse, CredentialWithKey } from "@/types";
 
 import { StepFlow, StepResponse } from "../step-flow";
@@ -22,7 +26,7 @@ export interface AuthorizeExecuteResponse {
   authorizeResponse?: AuthorizationResponse;
   iss: string;
   requestObject?: ParsedAuthorizeRequestResult["payload"];
-  requestObjectJwt: string;
+  requestObjectJwt?: string;
 }
 
 export interface AuthorizeStepOptions {
@@ -41,6 +45,11 @@ export interface AuthorizeStepOptions {
    * thumprint of the jwk in the cnf wallet attestation
    */
   clientId: string;
+
+  /**
+   * Identifier of the credential being issued
+   */
+  credentialIdentifier: string;
 
   /**
    * Credential tokens produced by the issuer
@@ -68,161 +77,234 @@ export type AuthorizeStepResponse = StepResponse & {
 };
 
 /**
- * Flow step to perform the authorization request to the issuer's authorization endpoint.
- * It constructs the authorization request, including the request object JWT,
- * and sends the request to obtain the authorization response.
+ * Opens the issuer's authorization URL in the system browser, starts a local
+ * HTTP callback server, and waits for the OAuth2 authorization code redirect.
  *
  * The response of this step includes:
- * - authorizeResponse: The authorization response from the issuer.
+ * - authorizeResponse: The authorization response from the issuer (code, iss, state).
  * - iss: The issuer identifier.
- * - requestObject: The parsed authorization request object (if parsing was successful).
- * - requestObjectJwt: The raw authorization request object JWT as a string.
  */
 export class AuthorizeDefaultStep extends StepFlow {
   static readonly tag = "AUTHORIZE";
 
+  async handlePidFlow({
+    authorizeUrl,
+    callbackPort,
+    redirectUri,
+  }: {
+    authorizeUrl: string;
+    callbackPort: number;
+    redirectUri: string;
+  }): Promise<AuthorizeExecuteResponse> {
+    this.log.debug(`Starting callback server on ${redirectUri}`);
+    const callbackPromise = startCallbackServer(callbackPort);
+
+    this.log.info(`Opening browser at: ${authorizeUrl}`);
+    openBrowser(authorizeUrl);
+
+    this.log.info(
+      "Waiting for the authorization callback... Complete the authentication flow in your browser.",
+    );
+    const authorizeResponse = await callbackPromise;
+
+    this.log.debug(
+      "Authorization callback received:",
+      JSON.stringify(authorizeResponse, null, 2),
+    );
+
+    return {
+      authorizeResponse,
+      iss: authorizeResponse.iss,
+    };
+  }
+
+  async handleQEEAFlow({
+    authorizeUrl,
+    options,
+  }: {
+    authorizeUrl: string;
+    options: AuthorizeStepOptions;
+  }): Promise<AuthorizeExecuteResponse> {
+    const fetchAuthorize = await fetchWithRetries(
+      authorizeUrl,
+      this.config.network,
+    );
+
+    const requestObjectJwt = await fetchAuthorize.response.text();
+    this.log.debug("Request Object JWT fetched successfully", requestObjectJwt);
+    const parsedAuthorizeRequest = await parseAuthorizeRequest({
+      callbacks: { verifyJwt },
+      config: this.ioWalletSdkConfig,
+      requestObjectJwt,
+    });
+    this.log.debug(
+      "Parsed Authorize Request:",
+      JSON.stringify(parsedAuthorizeRequest, null, 2),
+    );
+
+    const requestObject = parsedAuthorizeRequest.payload;
+    const responseUri = requestObject.response_uri;
+    if (!responseUri) {
+      this.log.error(
+        "Failed to obtain response uri from authorization request",
+      );
+      throw new Error(
+        "Failed to obtain response uri from authorization request",
+      );
+    }
+
+    const rpEncKey = options.rpMetadata.jwks.keys.find(
+      (key) => key.use === "enc",
+    );
+    if (!rpEncKey) {
+      this.log.error("No encryption key found in RP Metadata JWKS");
+      throw new Error("No encryption key found in RP Metadata JWKS");
+    }
+
+    const rpSigKey = options.rpMetadata.jwks.keys.find(
+      (key) => key.use === "sig",
+    );
+    if (!rpSigKey) {
+      this.log.error("No signature key found in RP Metadata JWKS");
+      throw new Error("No signature key found in RP Metadata JWKS");
+    }
+
+    const dcqlQuery = requestObject.dcql_query as DcqlQuery | undefined;
+    if (!dcqlQuery) {
+      throw new Error("dcql_query is missing in the request object");
+    }
+
+    if (!requestObject.state) {
+      throw new Error("state is missing in the authorization request object");
+    }
+
+    const vp_token = await buildVpToken(
+      options.credentials,
+      dcqlQuery,
+      {
+        client_id: requestObject.client_id,
+        nonce: requestObject.nonce,
+        responseUri: responseUri,
+      },
+      this.config.wallet.wallet_version,
+      this.log,
+    );
+    this.log.info("VP Token built successfully from DCQL query.");
+    this.log.debug("VP Token built:", JSON.stringify(vp_token, null, 2));
+
+    this.log.info("Creating Authorization Response...");
+    this.log.debug(
+      `Authorization response nonce: ${JSON.stringify({ nonce: requestObject.nonce })}`,
+    );
+    const createAuthorizationResponseOptions = {
+      authorization_encrypted_response_alg:
+        options.rpMetadata.authorization_encrypted_response_alg,
+      authorization_encrypted_response_enc:
+        options.rpMetadata.authorization_encrypted_response_enc,
+      callbacks: {
+        ...partialCallbacks,
+        encryptJwe: getEncryptJweCallback(),
+      },
+      config: this.ioWalletSdkConfig,
+      requestObject,
+      rpJwks: {
+        jwks: options.rpMetadata.jwks,
+      },
+      vp_token,
+    } as CreateAuthorizationResponseVersionedOptions;
+
+    const authorizationResponse = await createAuthorizationResponse(
+      createAuthorizationResponseOptions,
+    );
+    this.log.debug(
+      "Authorization Response created:",
+      JSON.stringify(authorizationResponse, null, 2),
+    );
+    if (!authorizationResponse.jarm) {
+      this.log.error("Failed to create authorization response JARM");
+      throw new Error("Failed to create authorization response JARM");
+    }
+
+    this.log.info(`Sending authorization response to: ${responseUri}`);
+    this.log.debug(`Authorization response iss: ${options.baseUrl}`);
+    const sendAuthorizationResponseAndExtractCodeOptions = {
+      authorizationResponseJarm: authorizationResponse.jarm.responseJwe,
+      callbacks: {
+        verifyJwt,
+      },
+      iss: options.baseUrl,
+      presentationResponseUri: responseUri,
+      signer: {
+        alg: "ES256",
+        method: "jwk" as const,
+        publicJwk: rpSigKey,
+      },
+      state: requestObject.state,
+    };
+
+    const authorizeResponse = await sendAuthorizationResponseAndExtractCode(
+      sendAuthorizationResponseAndExtractCodeOptions,
+    );
+    this.log.debug(
+      "Authorize response extracted code:",
+      JSON.stringify(authorizeResponse, null, 2),
+    );
+
+    return {
+      authorizeResponse,
+      iss: options.baseUrl,
+      requestObject,
+      requestObjectJwt,
+    };
+  }
+
   async run(options: AuthorizeStepOptions): Promise<AuthorizeStepResponse> {
-    const log = this.log;
+    this.log.debug(`Starting Authorize Step`);
+    const callbackPort = this.config.issuance.callback_port;
+    const redirectUri = getCallbackRedirectUri(callbackPort);
 
-    log.debug(`Starting Authorize Step`);
-
-    const authorizeUrl = `${options.authorizationEndpoint}?client_id=${options.clientId}&request_uri=${options.requestUri}`;
+    const authorizeUrl =
+      `${options.authorizationEndpoint}` +
+      `?client_id=${encodeURIComponent(options.clientId)}` +
+      `&request_uri=${encodeURIComponent(options.requestUri ?? "")}`;
 
     return this.execute<AuthorizeExecuteResponse>(async () => {
-      log.info("Fetching Authorize Request from", authorizeUrl);
-      const fetchAuthorize = await fetchWithRetries(
+      if (options.credentialIdentifier === "dc_sd_jwt_pid") {
+        return this.handlePidFlow({
+          authorizeUrl,
+          callbackPort,
+          redirectUri,
+        });
+      }
+
+      return this.handleQEEAFlow({
         authorizeUrl,
-        this.config.network,
-      );
-
-      const requestObjectJwt = await fetchAuthorize.response.text();
-      log.debug("Request Object JWT fetched successfully", requestObjectJwt);
-      const parsedAuthorizeRequest = await parseAuthorizeRequest({
-        callbacks: { verifyJwt },
-        config: this.ioWalletSdkConfig,
-        requestObjectJwt,
+        options,
       });
-      log.debug(
-        "Parsed Authorize Request:",
-        JSON.stringify(parsedAuthorizeRequest, null, 2),
-      );
-
-      const requestObject = parsedAuthorizeRequest.payload;
-      const responseUri = requestObject.response_uri;
-      if (!responseUri) {
-        log.error("Failed to obtain response uri from authorization request");
-        throw new Error(
-          "Failed to obtain response uri from authorization request",
-        );
-      }
-
-      const rpEncKey = options.rpMetadata.jwks.keys.find(
-        (key) => key.use === "enc",
-      );
-      if (!rpEncKey) {
-        log.error("No encryption key found in RP Metadata JWKS");
-        throw new Error("No encryption key found in RP Metadata JWKS");
-      }
-
-      const rpSigKey = options.rpMetadata.jwks.keys.find(
-        (key) => key.use === "sig",
-      );
-      if (!rpSigKey) {
-        log.error("No signature key found in RP Metadata JWKS");
-        throw new Error("No signature key found in RP Metadata JWKS");
-      }
-
-      const dcqlQuery = requestObject.dcql_query as DcqlQuery | undefined;
-      if (!dcqlQuery) {
-        throw new Error("dcql_query is missing in the request object");
-      }
-
-      if (!requestObject.state) {
-        throw new Error("state is missing in the authorization request object");
-      }
-
-      const vp_token = await buildVpToken(
-        options.credentials,
-        dcqlQuery,
-        {
-          client_id: requestObject.client_id,
-          nonce: requestObject.nonce,
-          responseUri: responseUri,
-        },
-        this.config.wallet.wallet_version,
-        this.log,
-      );
-      log.info("VP Token built successfully from DCQL query.");
-      log.debug("VP Token built:", JSON.stringify(vp_token, null, 2));
-
-      log.info("Creating Authorization Response...");
-      log.debug(
-        `Authorization response nonce: ${JSON.stringify({ nonce: requestObject.nonce })}`,
-      );
-      const createAuthorizationResponseOptions = {
-        authorization_encrypted_response_alg:
-          options.rpMetadata.authorization_encrypted_response_alg,
-        authorization_encrypted_response_enc:
-          options.rpMetadata.authorization_encrypted_response_enc,
-        callbacks: {
-          ...partialCallbacks,
-          encryptJwe: getEncryptJweCallback(),
-        },
-        config: this.ioWalletSdkConfig,
-        requestObject,
-        rpJwks: {
-          jwks: options.rpMetadata.jwks,
-        },
-        vp_token,
-      } as CreateAuthorizationResponseVersionedOptions;
-
-      const authorizationResponse = await createAuthorizationResponse(
-        createAuthorizationResponseOptions,
-      );
-      log.debug(
-        "Authorization Response created:",
-        JSON.stringify(authorizationResponse, null, 2),
-      );
-      if (!authorizationResponse.jarm) {
-        log.error("Failed to create authorization response JARM");
-        throw new Error("Failed to create authorization response JARM");
-      }
-
-      log.info(`Sending authorization response to: ${responseUri}`);
-      log.debug(`Authorization response iss: ${options.baseUrl}`);
-      const sendAuthorizationResponseAndExtractCodeOptions = {
-        authorizationResponseJarm: authorizationResponse.jarm.responseJwe,
-        callbacks: {
-          verifyJwt,
-        },
-        iss: options.baseUrl,
-        presentationResponseUri: responseUri,
-        signer: {
-          alg: "ES256",
-          method: "jwk" as const,
-          publicJwk: rpSigKey,
-        },
-        state: requestObject.state,
-      };
-
-      const authorizeResponse = await sendAuthorizationResponseAndExtractCode(
-        sendAuthorizationResponseAndExtractCodeOptions,
-      );
-      log.debug(
-        "Authorize response extracted code:",
-        JSON.stringify(authorizeResponse, null, 2),
-      );
-
-      return {
-        authorizeResponse,
-        iss: options.baseUrl,
-        requestObject,
-        requestObjectJwt,
-      };
     });
   }
 
   tag(): string {
     return AuthorizeDefaultStep.tag;
   }
+}
+
+/** Opens the given URL in the system default browser (cross-platform). */
+function openBrowser(url: string): void {
+  const os = platform();
+  let command: string;
+  if (os === "darwin") {
+    command = `open "${url}"`;
+  } else if (os === "win32") {
+    command = `start "" "${url}"`;
+  } else {
+    command = `xdg-open "${url}"`;
+  }
+  exec(command, (err) => {
+    if (err) {
+      // Non-fatal: the user can copy-paste the URL manually if the auto-open fails.
+      console.warn(`Could not open browser automatically: ${err.message}`);
+      console.warn(`Please open the following URL manually:\n  ${url}`);
+    }
+  });
 }

--- a/src/step/issuance/authorize-step.ts
+++ b/src/step/issuance/authorize-step.ts
@@ -4,9 +4,9 @@ import {
 } from "@pagopa/io-wallet-oid4vci";
 import {
   createAuthorizationResponse,
-  CreateAuthorizationResponseVersionedOptions,
+  type CreateAuthorizationResponseVersionedOptions,
   parseAuthorizeRequest,
-  ParsedAuthorizeRequestResult,
+  type ParsedAuthorizeRequestResult,
 } from "@pagopa/io-wallet-oid4vp";
 import { ItWalletCredentialVerifierMetadata } from "@pagopa/io-wallet-oid-federation";
 import { DcqlQuery } from "dcql";

--- a/src/step/issuance/authorize-step.ts
+++ b/src/step/issuance/authorize-step.ts
@@ -292,13 +292,14 @@ export class AuthorizeDefaultStep extends StepFlow {
 /** Opens the given URL in the system default browser (cross-platform). */
 function openBrowser(url: string): void {
   const os = platform();
+  const quotedUrl = JSON.stringify(url);
   let command: string;
   if (os === "darwin") {
-    command = `open "${url}"`;
+    command = `open ${quotedUrl}`;
   } else if (os === "win32") {
-    command = `start "" "${url}"`;
+    command = `start "" ${quotedUrl}`;
   } else {
-    command = `xdg-open "${url}"`;
+    command = `xdg-open ${quotedUrl}`;
   }
   exec(command, (err) => {
     if (err) {

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -18,6 +18,7 @@ import {
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
 } from "@pagopa/io-wallet-utils";
+import { randomUUID } from "node:crypto";
 
 import {
   buildJwksPath,
@@ -49,11 +50,6 @@ export interface CredentialRequestStepOptions {
   accessToken: string;
 
   /**
-   * Credential Issuer Base URL
-   */
-  baseUrl: string;
-
-  /**
    * Client ID of the OAuth2 Client, it will be loaded from the wallet attestation public key kid
    */
   clientId: string;
@@ -72,6 +68,11 @@ export interface CredentialRequestStepOptions {
    * Identifier of the credential to request, used to select the credential from the issuer metadata,
    */
   credentialIdentifier: string;
+
+  /**
+   * Credential Issuer Base URL
+   */
+  credentialIssuer: string;
 
   /**
    * Credential Request Endpoint URL, it will be loaded from the issuer metadata
@@ -129,7 +130,7 @@ export class CredentialRequestDefaultStep extends StepFlow {
         signJwt: signJwtCallback([providerKey.privateKey]),
       },
       issuer: getLocalWpBaseUrl(this.config.wallet.port),
-      keyStorage: ["iso_18045_basic"],
+      keyStorage: ["iso_18045_moderate"],
       signer: {
         alg: "ES256",
         kid: providerKey.publicKey.kid,
@@ -138,11 +139,11 @@ export class CredentialRequestDefaultStep extends StepFlow {
       },
       status: {
         status_list: {
-          idx: 0,
-          uri: `${getLocalWpBaseUrl(this.config.wallet.port)}/status-list`,
+          idx: 4373,
+          uri: `https://iwuitncdnst01.blob.core.windows.net/status-lists/ae783554-e4cd-4646-a73e-337a0062c60d`,
         },
       },
-      userAuthentication: ["iso_18045_basic"],
+      userAuthentication: ["iso_18045_moderate"],
     });
   }
 
@@ -214,7 +215,7 @@ export class CredentialRequestDefaultStep extends StepFlow {
       },
       clientId: options.clientId,
       credential_identifier: options.credentialIdentifier,
-      issuerIdentifier: options.baseUrl,
+      issuerIdentifier: options.credentialIssuer,
       nonce: options.nonce,
     };
 
@@ -276,6 +277,7 @@ export class CredentialRequestDefaultStep extends StepFlow {
         ...partialCallbacks,
         signJwt: signJwtCallback([dPoPKey.privateKey]),
       },
+      jti: randomUUID(),
       signer: {
         alg: "ES256",
         method: "jwk",

--- a/src/step/issuance/pushed-authorization-request-step.ts
+++ b/src/step/issuance/pushed-authorization-request-step.ts
@@ -17,6 +17,11 @@ export type PushedAuthorizationRequestExecuteResponse =
      * Code verifier used in the Pushed Authorization Request, if not provided it will be generated internally
      */
     codeVerifier: string;
+
+    /**
+     * State value sent in the authorization request, it can be used to correlate the authorization response with the request
+     */
+    state: string;
   };
 
 export type PushedAuthorizationRequestResponse = StepResponse & {
@@ -89,6 +94,7 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
           signJwt: signJwtCallback([unitKey.privateKey]),
         };
 
+        const state = crypto.randomUUID();
         const createParOptions = {
           audience: options.baseUrl,
           authorization_details: options.credentialConfigurationIds.map(
@@ -119,6 +125,7 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
             this.config.issuance.callback_port,
           ),
           responseMode: "query",
+          state,
         };
 
         const finalParOptions = {
@@ -169,6 +176,7 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
         return {
           ...parResponse,
           codeVerifier,
+          state,
         };
       },
     );

--- a/src/step/issuance/pushed-authorization-request-step.ts
+++ b/src/step/issuance/pushed-authorization-request-step.ts
@@ -7,7 +7,7 @@ import {
 } from "@pagopa/io-wallet-oauth2";
 
 import { fetchWithConfig, partialCallbacks, signJwtCallback } from "@/logic";
-import { REDIRECT_URI } from "@/logic/constants";
+import { getCallbackRedirectUri } from "@/logic/constants";
 import { StepFlow, StepResponse } from "@/step";
 import { AttestationResponse } from "@/types";
 
@@ -115,7 +115,9 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
             },
           },
           pkceCodeVerifier: options.codeVerifier,
-          redirectUri: REDIRECT_URI,
+          redirectUri: getCallbackRedirectUri(
+            this.config.issuance.callback_port,
+          ),
           responseMode: "query",
         };
 
@@ -137,6 +139,11 @@ export class PushedAuthorizationRequestDefaultStep extends StepFlow {
         );
         const pushedAuthorizationRequest =
           await createPushedAuthorizationRequest(finalParOptions);
+
+        log.debug(
+          "Pushed Authorization Request:",
+          JSON.stringify(pushedAuthorizationRequest.request, null, 2),
+        );
 
         const codeVerifier = pushedAuthorizationRequest.pkceCodeVerifier;
 

--- a/src/step/issuance/token-request-step.ts
+++ b/src/step/issuance/token-request-step.ts
@@ -7,7 +7,7 @@ import {
   FetchTokenResponseOptions,
   Jwk,
 } from "@pagopa/io-wallet-oauth2";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 
 import {
   createKeys,

--- a/src/step/issuance/token-request-step.ts
+++ b/src/step/issuance/token-request-step.ts
@@ -7,6 +7,7 @@ import {
   FetchTokenResponseOptions,
   Jwk,
 } from "@pagopa/io-wallet-oauth2";
+import { randomUUID } from "crypto";
 
 import {
   createKeys,
@@ -84,6 +85,7 @@ export class TokenRequestDefaultStep extends StepFlow {
           ...partialCallbacks,
           signJwt: signJwtCallback([dPoPKey.privateKey]),
         },
+        jti: randomUUID(),
         signer: {
           alg: "ES256",
           method: "jwk",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -16,6 +16,12 @@ const zBooleanFromString = z.union([z.boolean(), z.stringbool()]);
  */
 export const configSchema = z.object({
   issuance: z.object({
+    /**
+     * Port on which the local OAuth2 callback server listens.
+     * The `redirect_uri` used in PAR and token requests is
+     * `http://localhost:{callback_port}/cb`.
+     */
+    callback_port: z.coerce.number().default(4000),
     certificate_subject: z.string().optional(),
     credential_offer_uri: z
       .string()

--- a/tests/conformance/issuance/authorization-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/authorization-validation.issuance.spec.ts
@@ -59,6 +59,7 @@ testConfigs.forEach((testConfig) => {
         authorizationEndpoint,
         baseUrl: credentialIssuer,
         clientId: walletAttestationResponse.unitKey.publicKey.kid,
+        credentialIdentifier: testConfig.credentialConfigurationId,
         credentials: [],
         requestUri: requestUri ?? "",
         rpMetadata: entityClaims?.metadata?.openid_credential_verifier,

--- a/tests/conformance/issuance/credential-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/credential-validation.issuance.spec.ts
@@ -157,9 +157,9 @@ testConfigs.forEach((testConfig) => {
       const step = new StepClass(config, baseLog);
       return step.run({
         accessToken,
-        baseUrl: credentialIssuer,
         clientId: walletAttestationResponse.unitKey.publicKey.kid,
         credentialIdentifier: credentialConfigurationId,
+        credentialIssuer: credentialIssuer,
         credentialRequestEndpoint: credentialEndpoint,
         dPoPKey: tokenCtx.dPoPKey,
         nonce,

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -899,7 +899,9 @@ testConfigs.forEach((testConfig) => {
 
       let testSuccess = false;
       try {
-        expect(authorizeResponse.response?.requestObjectJwt).toBeDefined();
+        expect(
+          authorizeResponse.response?.authorizeResponse?.code,
+        ).toBeDefined();
 
         testSuccess = true;
       } finally {
@@ -936,7 +938,7 @@ testConfigs.forEach((testConfig) => {
       try {
         const responseState =
           authorizeResponse.response?.authorizeResponse?.state;
-        const requestState = authorizeResponse.response?.requestObject?.state;
+        const requestState = pushedAuthorizationRequestResponse.response?.state;
 
         expect(responseState).toBeDefined();
         expect(typeof responseState).toBe("string");

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -853,6 +853,34 @@ testConfigs.forEach((testConfig) => {
       }
     });
 
+    test(
+      "CI_051: CieID High-Level Authentication | PID Provider successfully performs User authentication based on CieID scheme with LoAHigh (CIE L3)",
+      { skip: testConfig.credentialConfigurationId !== "dc_sd_jwt_pid" },
+      async () => {
+        const log = baseLog.withTag("CI_051");
+        const DESCRIPTION =
+          "PID Provider successfully performs User authentication based on CieID scheme with LoAHigh (CIE L3)";
+
+        log.start(
+          "Conformance test: Verifying PID Provider performs User authentication based on CieID scheme with LoAHigh (CIE L3)",
+        );
+
+        let testSuccess = false;
+        try {
+          expect(
+            credentialResponse.response?.credentials?.length,
+          ).toBeGreaterThan(0);
+          log.debug(
+            `  Credentials received: ${credentialResponse.response?.credentials?.length}`,
+          );
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
+
     test("CI_054: Authorization | (Q)EAA Provider successfully performs User authentication by requesting and validating a valid PID from the Wallet Instance", async () => {
       const log = baseLog.withTag("CI_054");
       const DESCRIPTION =

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -2,6 +2,10 @@
 
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertIssuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
+import {
+  assertPidJwtPayloadClaims,
+  assertPidSdDisclosures,
+} from "#/helpers/pid-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
 import { JwkSet } from "@pagopa/io-wallet-oauth2";
 import { fetchMetadata } from "@pagopa/io-wallet-oid4vci";
@@ -38,113 +42,6 @@ import { AttestationResponse } from "@/types";
 
 // Define and auto-register test configuration
 const testConfigs = await defineIssuanceTest("HappyFlowIssuance");
-
-// ---------------------------------------------------------------------------
-// CI_117 helper functions
-// ---------------------------------------------------------------------------
-
-function assertPidJwtPayloadClaims(
-  payload: Record<string, unknown>,
-  isV1_0: boolean,
-): void {
-  expect(
-    typeof payload["sub"] === "string" && (payload["sub"] as string).length > 0,
-    "sub must be a non-empty string in the JWT payload",
-  ).toBe(true);
-
-  expect(typeof payload["iat"], "iat must be a number in the JWT payload").toBe(
-    "number",
-  );
-
-  expect(
-    typeof payload["cnf"] === "object" && payload["cnf"] !== null,
-    "cnf must be a non-null object in the JWT payload",
-  ).toBe(true);
-
-  expect(
-    typeof payload["status"] === "object" && payload["status"] !== null,
-    "status must be a non-null object in the JWT payload",
-  ).toBe(true);
-
-  if (!isV1_0) {
-    expect(
-      typeof payload["verification"] === "object" &&
-        payload["verification"] !== null,
-      "verification must be a non-null object in the JWT payload (V1.3 domestic extension)",
-    ).toBe(true);
-  }
-}
-
-function assertPidSdDisclosures(
-  disclosureMap: Map<string, unknown>,
-  isV1_0: boolean,
-): void {
-  expect(
-    typeof disclosureMap.get("given_name"),
-    "given_name must be a selectively disclosable string",
-  ).toBe("string");
-
-  expect(
-    typeof disclosureMap.get("family_name"),
-    "family_name must be a selectively disclosable string",
-  ).toBe("string");
-
-  const birthdateKey = isV1_0 ? "birth_date" : "birthdate";
-  const birthdateValue = disclosureMap.get(birthdateKey);
-  expect(
-    birthdateValue,
-    `${birthdateKey} must be present as a disclosure`,
-  ).toBeDefined();
-  expect(
-    typeof birthdateValue === "string" &&
-      /^\d{4}-\d{2}-\d{2}$/.test(birthdateValue),
-    `${birthdateKey} must be a string in YYYY-MM-DD format`,
-  ).toBe(true);
-
-  if (isV1_0) {
-    expect(
-      typeof disclosureMap.get("birth_place"),
-      "birth_place (V1.0) must be a selectively disclosable string",
-    ).toBe("string");
-  } else {
-    const pob = disclosureMap.get("place_of_birth");
-    expect(pob, "place_of_birth must be present as a disclosure").toBeDefined();
-    expect(
-      typeof pob === "object" && pob !== null && !Array.isArray(pob),
-      "place_of_birth must be a JSON object",
-    ).toBe(true);
-    const pobObj = pob as Record<string, unknown>;
-    expect(
-      pobObj["country"] !== undefined ||
-        pobObj["region"] !== undefined ||
-        pobObj["locality"] !== undefined,
-      "place_of_birth must contain at least one of: country, region, locality",
-    ).toBe(true);
-  }
-
-  const nats = disclosureMap.get("nationalities");
-  expect(nats, "nationalities must be present as a disclosure").toBeDefined();
-  expect(Array.isArray(nats), "nationalities must be an array").toBe(true);
-  for (const code of nats as unknown[]) {
-    expect(
-      typeof code === "string" && /^[A-Z]{2}$/.test(code),
-      `nationalities entry "${String(code)}" must be an ISO 3166-1 alpha-2 code`,
-    ).toBe(true);
-  }
-
-  const expiryKey = isV1_0 ? "expiry_date" : "date_of_expiry";
-  expect(
-    disclosureMap.get(expiryKey),
-    `${expiryKey} must be present as a disclosure`,
-  ).toBeDefined();
-
-  const pan = disclosureMap.get("personal_administrative_number");
-  const tic = disclosureMap.get("tax_id_code");
-  expect(
-    pan !== undefined || tic !== undefined,
-    "At least one of personal_administrative_number or tax_id_code must be disclosed",
-  ).toBe(true);
-}
 
 testConfigs.forEach((testConfig) => {
   describe(`[${testConfig.name}] Credential Issuer Tests`, () => {

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -15,6 +15,8 @@ import {
   ItWalletSpecsVersion,
 } from "@pagopa/io-wallet-utils";
 import { SDJwt } from "@sd-jwt/core";
+import { digest } from "@sd-jwt/crypto-nodejs";
+import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
 import { DcqlQuery } from "dcql";
 import { calculateJwkThumbprint, decodeJwt } from "jose";
 import { beforeAll, describe, expect, test } from "vitest";
@@ -36,6 +38,113 @@ import { AttestationResponse } from "@/types";
 
 // Define and auto-register test configuration
 const testConfigs = await defineIssuanceTest("HappyFlowIssuance");
+
+// ---------------------------------------------------------------------------
+// CI_117 helper functions
+// ---------------------------------------------------------------------------
+
+function assertPidJwtPayloadClaims(
+  payload: Record<string, unknown>,
+  isV1_0: boolean,
+): void {
+  expect(
+    typeof payload["sub"] === "string" && (payload["sub"] as string).length > 0,
+    "sub must be a non-empty string in the JWT payload",
+  ).toBe(true);
+
+  expect(typeof payload["iat"], "iat must be a number in the JWT payload").toBe(
+    "number",
+  );
+
+  expect(
+    typeof payload["cnf"] === "object" && payload["cnf"] !== null,
+    "cnf must be a non-null object in the JWT payload",
+  ).toBe(true);
+
+  expect(
+    typeof payload["status"] === "object" && payload["status"] !== null,
+    "status must be a non-null object in the JWT payload",
+  ).toBe(true);
+
+  if (!isV1_0) {
+    expect(
+      typeof payload["verification"] === "object" &&
+        payload["verification"] !== null,
+      "verification must be a non-null object in the JWT payload (V1.3 domestic extension)",
+    ).toBe(true);
+  }
+}
+
+function assertPidSdDisclosures(
+  disclosureMap: Map<string, unknown>,
+  isV1_0: boolean,
+): void {
+  expect(
+    typeof disclosureMap.get("given_name"),
+    "given_name must be a selectively disclosable string",
+  ).toBe("string");
+
+  expect(
+    typeof disclosureMap.get("family_name"),
+    "family_name must be a selectively disclosable string",
+  ).toBe("string");
+
+  const birthdateKey = isV1_0 ? "birth_date" : "birthdate";
+  const birthdateValue = disclosureMap.get(birthdateKey);
+  expect(
+    birthdateValue,
+    `${birthdateKey} must be present as a disclosure`,
+  ).toBeDefined();
+  expect(
+    typeof birthdateValue === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(birthdateValue),
+    `${birthdateKey} must be a string in YYYY-MM-DD format`,
+  ).toBe(true);
+
+  if (isV1_0) {
+    expect(
+      typeof disclosureMap.get("birth_place"),
+      "birth_place (V1.0) must be a selectively disclosable string",
+    ).toBe("string");
+  } else {
+    const pob = disclosureMap.get("place_of_birth");
+    expect(pob, "place_of_birth must be present as a disclosure").toBeDefined();
+    expect(
+      typeof pob === "object" && pob !== null && !Array.isArray(pob),
+      "place_of_birth must be a JSON object",
+    ).toBe(true);
+    const pobObj = pob as Record<string, unknown>;
+    expect(
+      pobObj["country"] !== undefined ||
+        pobObj["region"] !== undefined ||
+        pobObj["locality"] !== undefined,
+      "place_of_birth must contain at least one of: country, region, locality",
+    ).toBe(true);
+  }
+
+  const nats = disclosureMap.get("nationalities");
+  expect(nats, "nationalities must be present as a disclosure").toBeDefined();
+  expect(Array.isArray(nats), "nationalities must be an array").toBe(true);
+  for (const code of nats as unknown[]) {
+    expect(
+      typeof code === "string" && /^[A-Z]{2}$/.test(code),
+      `nationalities entry "${String(code)}" must be an ISO 3166-1 alpha-2 code`,
+    ).toBe(true);
+  }
+
+  const expiryKey = isV1_0 ? "expiry_date" : "date_of_expiry";
+  expect(
+    disclosureMap.get(expiryKey),
+    `${expiryKey} must be present as a disclosure`,
+  ).toBeDefined();
+
+  const pan = disclosureMap.get("personal_administrative_number");
+  const tic = disclosureMap.get("tax_id_code");
+  expect(
+    pan !== undefined || tic !== undefined,
+    "At least one of personal_administrative_number or tax_id_code must be disclosed",
+  ).toBe(true);
+}
 
 testConfigs.forEach((testConfig) => {
   describe(`[${testConfig.name}] Credential Issuer Tests`, () => {
@@ -1297,6 +1406,69 @@ testConfigs.forEach((testConfig) => {
         log.testCompleted(DESCRIPTION, testSuccess);
       }
     });
+
+    test(
+      "CI_117: Credential | The Italian PID is successfully provided with the User attributes defined in the PID table",
+      { skip: testConfig.credentialConfigurationId !== "dc_sd_jwt_pid" },
+      async () => {
+        const log = baseLog.withTag("CI_117");
+        const DESCRIPTION =
+          "Italian PID contains all mandatory user attributes as SD disclosures and required metadata claims";
+
+        log.start(
+          "Conformance test: Verifying Italian PID user attributes and metadata claims",
+        );
+
+        let testSuccess = false;
+        try {
+          const isV1_0 = sdkConfig.isVersion(ItWalletSpecsVersion.V1_0);
+
+          const sdJwtCredentials: string[] = [];
+          for (const credObj of credentialResponse.response?.credentials ??
+            []) {
+            try {
+              await SDJwt.extractJwt(credObj.credential);
+              sdJwtCredentials.push(credObj.credential);
+            } catch {
+              /* non-SD-JWT, skip */
+            }
+          }
+
+          expect(
+            sdJwtCredentials.length,
+            "At least one SD-JWT PID credential must be present",
+          ).toBeGreaterThan(0);
+
+          const instance = new SDJwtVcInstance({ hasher: digest });
+
+          for (const credentialJwt of sdJwtCredentials) {
+            const decoded = await instance.decode(credentialJwt);
+            const payload = decoded.jwt?.payload as Record<string, unknown>;
+
+            const disclosureMap = new Map<string, unknown>();
+            for (const disc of decoded.disclosures ?? []) {
+              if (disc.key !== undefined)
+                disclosureMap.set(disc.key, disc.value);
+            }
+
+            log.debug(
+              `  Disclosed claims: ${JSON.stringify([...disclosureMap.keys()])}`,
+            );
+
+            assertPidSdDisclosures(disclosureMap, isV1_0);
+            assertPidJwtPayloadClaims(payload, isV1_0);
+
+            log.debug(
+              "  ✓ All mandatory PID user attributes and metadata claims validated",
+            );
+          }
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
 
     test("CI_118: Credential | (Q)EAA are Issued to a Wallet Instance in SD-JWT VC or mdoc-CBOR data format.", async () => {
       const log = baseLog.withTag("CI_118");

--- a/tests/conformance/issuance/sd-jwt-data-model.issuance.spec.ts
+++ b/tests/conformance/issuance/sd-jwt-data-model.issuance.spec.ts
@@ -2,6 +2,10 @@
 
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertIssuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
+import {
+  assertPidJwtPayloadClaims,
+  assertPidSdDisclosures,
+} from "#/helpers/pid-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
 import {
   IoWalletSdkConfig,
@@ -33,6 +37,9 @@ testConfigs.forEach((testConfig) => {
   describe(`[${testConfig.name}] SD-JWT VC Data Model Tests`, () => {
     const orchestrator = new WalletIssuanceOrchestratorFlow(testConfig);
     const baseLog = orchestrator.getLog();
+    const sdkConfig = new IoWalletSdkConfig({
+      itWalletSpecsVersion: orchestrator.getConfig().wallet.wallet_version,
+    });
 
     let credentialResponse: CredentialRequestResponse;
     let credentialIssuer: string;
@@ -1396,5 +1403,68 @@ testConfigs.forEach((testConfig) => {
         log.testCompleted(DESCRIPTION, testSuccess);
       }
     });
+
+    test(
+      "CI_136: Additional PID Claims | Additional claims data is successfully incorporated when required",
+      { skip: testConfig.credentialConfigurationId !== "dc_sd_jwt_pid" },
+      async () => {
+        const log = baseLog.withTag("CI_136");
+        const DESCRIPTION =
+          "Italian PID contains all mandatory user attributes as SD disclosures and required metadata claims";
+
+        log.start(
+          "Conformance test: Verifying Italian PID user attributes and metadata claims",
+        );
+
+        let testSuccess = false;
+        try {
+          const isV1_0 = sdkConfig.isVersion(ItWalletSpecsVersion.V1_0);
+
+          const sdJwtCredentials: string[] = [];
+          for (const credObj of credentialResponse.response?.credentials ??
+            []) {
+            try {
+              await SDJwt.extractJwt(credObj.credential);
+              sdJwtCredentials.push(credObj.credential);
+            } catch {
+              /* non-SD-JWT, skip */
+            }
+          }
+
+          expect(
+            sdJwtCredentials.length,
+            "At least one SD-JWT PID credential must be present",
+          ).toBeGreaterThan(0);
+
+          const instance = new SDJwtVcInstance({ hasher: digest });
+
+          for (const credentialJwt of sdJwtCredentials) {
+            const decoded = await instance.decode(credentialJwt);
+            const payload = decoded.jwt?.payload as Record<string, unknown>;
+
+            const disclosureMap = new Map<string, unknown>();
+            for (const disc of decoded.disclosures ?? []) {
+              if (disc.key !== undefined)
+                disclosureMap.set(disc.key, disc.value);
+            }
+
+            log.debug(
+              `  Disclosed claims: ${JSON.stringify([...disclosureMap.keys()])}`,
+            );
+
+            assertPidSdDisclosures(disclosureMap, isV1_0);
+            assertPidJwtPayloadClaims(payload, isV1_0);
+
+            log.debug(
+              "  ✓ All mandatory PID user attributes and metadata claims validated",
+            );
+          }
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
   });
 });

--- a/tests/helpers/pid-helpers.ts
+++ b/tests/helpers/pid-helpers.ts
@@ -1,0 +1,104 @@
+import { expect } from "vitest";
+
+export const assertPidJwtPayloadClaims = (
+  payload: Record<string, unknown>,
+  isV1_0: boolean,
+): void => {
+  expect(
+    typeof payload["sub"] === "string" && (payload["sub"] as string).length > 0,
+    "sub must be a non-empty string in the JWT payload",
+  ).toBe(true);
+
+  expect(typeof payload["iat"], "iat must be a number in the JWT payload").toBe(
+    "number",
+  );
+
+  expect(
+    typeof payload["cnf"] === "object" && payload["cnf"] !== null,
+    "cnf must be a non-null object in the JWT payload",
+  ).toBe(true);
+
+  expect(
+    typeof payload["status"] === "object" && payload["status"] !== null,
+    "status must be a non-null object in the JWT payload",
+  ).toBe(true);
+
+  if (!isV1_0) {
+    expect(
+      typeof payload["verification"] === "object" &&
+        payload["verification"] !== null,
+      "verification must be a non-null object in the JWT payload (V1.3 domestic extension)",
+    ).toBe(true);
+  }
+};
+
+export const assertPidSdDisclosures = (
+  disclosureMap: Map<string, unknown>,
+  isV1_0: boolean,
+): void => {
+  expect(
+    typeof disclosureMap.get("given_name"),
+    "given_name must be a selectively disclosable string",
+  ).toBe("string");
+
+  expect(
+    typeof disclosureMap.get("family_name"),
+    "family_name must be a selectively disclosable string",
+  ).toBe("string");
+
+  const birthdateKey = isV1_0 ? "birth_date" : "birthdate";
+  const birthdateValue = disclosureMap.get(birthdateKey);
+  expect(
+    birthdateValue,
+    `${birthdateKey} must be present as a disclosure`,
+  ).toBeDefined();
+  expect(
+    typeof birthdateValue === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(birthdateValue),
+    `${birthdateKey} must be a string in YYYY-MM-DD format`,
+  ).toBe(true);
+
+  if (isV1_0) {
+    expect(
+      typeof disclosureMap.get("birth_place"),
+      "birth_place (V1.0) must be a selectively disclosable string",
+    ).toBe("string");
+  } else {
+    const pob = disclosureMap.get("place_of_birth");
+    expect(pob, "place_of_birth must be present as a disclosure").toBeDefined();
+    expect(
+      typeof pob === "object" && pob !== null && !Array.isArray(pob),
+      "place_of_birth must be a JSON object",
+    ).toBe(true);
+    const pobObj = pob as Record<string, unknown>;
+    expect(
+      pobObj["country"] !== undefined ||
+        pobObj["region"] !== undefined ||
+        pobObj["locality"] !== undefined,
+      "place_of_birth must contain at least one of: country, region, locality",
+    ).toBe(true);
+  }
+
+  const nats = disclosureMap.get("nationalities");
+  expect(nats, "nationalities must be present as a disclosure").toBeDefined();
+  expect(Array.isArray(nats), "nationalities must be an array").toBe(true);
+  for (const code of nats as unknown[]) {
+    expect(
+      typeof code === "string" && /^[A-Z]{2}$/.test(code),
+      `nationalities entry "${String(code)}" must be an ISO 3166-1 alpha-2 code`,
+    ).toBe(true);
+  }
+
+  const expiryKey = isV1_0 ? "expiry_date" : "date_of_expiry";
+  expect(
+    disclosureMap.get(expiryKey),
+    `${expiryKey} must be present as a disclosure`,
+  ).toBeDefined();
+
+  const pan = disclosureMap.get("personal_administrative_number");
+  const tic = disclosureMap.get("tax_id_code");
+  expect(
+    pan !== undefined || tic !== undefined,
+    "At least one of personal_administrative_number or tax_id_code must be disclosed",
+  ).toBe(true);
+};

--- a/tests/helpers/token-validation-helpers.ts
+++ b/tests/helpers/token-validation-helpers.ts
@@ -30,9 +30,6 @@ export async function runAndValidateAuthorize(
 
   const code = authorizeResponse.response.authorizeResponse.code;
 
-  if (!authorizeResponse.response?.requestObject)
-    throw new Error("Authorization Response not found");
-
   if (!pushedAuthorizationRequestResponse.response)
     throw new Error(
       "Pushed Authorization Request Step did not return code_verifier",

--- a/tests/helpers/token-validation-helpers.ts
+++ b/tests/helpers/token-validation-helpers.ts
@@ -1,4 +1,4 @@
-import { REDIRECT_URI } from "@/logic/constants";
+import { getCallbackRedirectUri } from "@/logic/constants";
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
 import {
   AuthorizeStepResponse,
@@ -40,12 +40,14 @@ export async function runAndValidateAuthorize(
 
   const codeVerifier = pushedAuthorizationRequestResponse.response.codeVerifier;
 
+  const config = orchestrator.getConfig();
+
   return {
     authorizationServer,
     code,
     codeVerifier,
     fetchMetadataResponse,
-    redirectUri: REDIRECT_URI,
+    redirectUri: getCallbackRedirectUri(config.issuance.callback_port),
     walletAttestationResponse,
   };
 }

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -114,6 +114,11 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
 
 describe("loadConfigWithHierarchy – path resolution", () => {
   it("should resolve package fallback data paths under the package root", () => {
+    // An empty local config.ini in the CWD takes priority over any config.ini
+    // that may exist in the package root (e.g. a developer's local config),
+    // ensuring only the default config.example.ini paths are in effect.
+    writeFileSync(path.join(process.cwd(), "config.ini"), "");
+
     const config = loadConfigWithHierarchy({}, DEFAULT_INI);
 
     expect(config.wallet.backup_storage_path).toBe(

--- a/tests/unit/credentials.unit.spec.ts
+++ b/tests/unit/credentials.unit.spec.ts
@@ -486,7 +486,9 @@ describe("Load Mocked Credentials", async () => {
 
       // In order to make KSUID work, the date should be after its internal base epoch, May 13, 2014
       const date = new Date(2015, 1, 1);
-      const twoYearsLater = addSecondsToDate(date, 3600 * 24 * 365 * 2);
+      // Advance by 2 years + 60 s to clear the 30-second clock-skew tolerance
+      // used in the credential expiry check (exp < Date.now() - 30 s).
+      const twoYearsLater = addSecondsToDate(date, 3600 * 24 * 365 * 2 + 60);
 
       try {
         vi.useFakeTimers();

--- a/tests/unit/tls-server.unit.spec.ts
+++ b/tests/unit/tls-server.unit.spec.ts
@@ -39,7 +39,9 @@ describe("Load server certificate test", async () => {
 
   it("should regenerate the certificate once it's expired", async () => {
     const now = new Date(2015, 1, 1);
-    const twoYearsLater = addSecondsToDate(now, 3600 * 24 * 365 * 2);
+    // Advance by 2 years + 60 s to clear the 30-second clock-skew tolerance
+    // used in hasX509CertificateExpired (notAfter < Date.now() - 30 s).
+    const twoYearsLater = addSecondsToDate(now, 3600 * 24 * 365 * 2 + 60);
     vi.useFakeTimers();
 
     vi.setSystemTime(now);


### PR DESCRIPTION
#### Motivation and Context

Support PID Provider's authorization flow in order to cover PID test in Credential Issuer Test Matrix. This flow makes the issuance flow interactive (opens a real browser and waits for a loopback callback). This will hang or fail in non-interactive environments such as CI runners.

#### How Has This Been Tested?

Changes have been tested through conformance tests for PID Provider user authentication based on the CieID scheme with LoAHigh in pre.eid.wallet.ipzs.it environment using Wallet Provider PagoPA crypto material. Currently, this tool iis not able to test this flow with auto-generate crypto material

