### PR TITLE
chore(ci): remove tag check on publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,22 +41,6 @@ jobs:
           npm install --global npm@^11.15.0
           npm --version
 
-      - name: Validate release tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
-            echo "::error::This workflow must run from a version tag (for example v1.2.3)." >&2
-            exit 1
-          fi
-
-          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
-          expected_tag="v${package_version}"
-
-          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
-            echo "::error::Git tag ${GITHUB_REF_NAME} does not match expected tag ${expected_tag} for package.json version ${package_version}." >&2
-            exit 1
-          fi
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,6 @@
 name: Publish package to npm
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/publish.yml` file, removing the automatic trigger for publishing the package to npm when a version tag is pushed. Now, publishing can only be triggered manually using `workflow_dispatch`.