### PR TITLE
Add key attestation overrides for CI-034 conformance testing

### DIFF
--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -109,7 +109,6 @@ export type KeyAttestationOptions = Parameters<
   WalletProvider["createItKeyAttestationJwt"]
 >[0];
 
-
 /**
  * Flow step to request a credential from the issuer's credential endpoint.
  * It uses the access token obtained in the Token Request Step and the nonce from the Nonce Request Step.

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -101,11 +101,6 @@ export interface CredentialRequestStepOptions {
    */
   walletAttestation: Omit<AttestationResponse, "created">;
 }
-
-/**
- * Flow step to request a credential from the issuer's credential endpoint.
- * It uses the access token obtained in the Token Request Step and the nonce from the Nonce Request Step.
- */
 /**
  * The parameter type of `WalletProvider.createItKeyAttestationJwt`, derived
  * directly from the SDK so it never drifts from the installed version.
@@ -114,6 +109,11 @@ export type KeyAttestationOptions = Parameters<
   WalletProvider["createItKeyAttestationJwt"]
 >[0];
 
+
+/**
+ * Flow step to request a credential from the issuer's credential endpoint.
+ * It uses the access token obtained in the Token Request Step and the nonce from the Nonce Request Step.
+ */
 export class CredentialRequestDefaultStep extends StepFlow {
   static readonly tag = "CREDENTIAL_REQUEST";
 

--- a/src/step/issuance/credential-request-step.ts
+++ b/src/step/issuance/credential-request-step.ts
@@ -106,8 +106,29 @@ export interface CredentialRequestStepOptions {
  * Flow step to request a credential from the issuer's credential endpoint.
  * It uses the access token obtained in the Token Request Step and the nonce from the Nonce Request Step.
  */
+/**
+ * The parameter type of `WalletProvider.createItKeyAttestationJwt`, derived
+ * directly from the SDK so it never drifts from the installed version.
+ */
+export type KeyAttestationOptions = Parameters<
+  WalletProvider["createItKeyAttestationJwt"]
+>[0];
+
 export class CredentialRequestDefaultStep extends StepFlow {
   static readonly tag = "CREDENTIAL_REQUEST";
+
+  /**
+   * Optional overrides merged into the key attestation options before signing.
+   * Intended for conformance tests that need to submit non-standard security
+   * claim values (e.g. unsupported keyStorage / userAuthentication levels) to
+   * verify that the Credential Issuer enforces its security requirements.
+   *
+   * When set, fields in this object replace the corresponding defaults computed
+   * inside `createKeyAttestation`. The SDK does not perform runtime Zod
+   * validation on these fields, so intentionally non-compliant string values
+   * will reach the issuer inside the signed JWT.
+   */
+  protected keyAttestationOverrides?: Partial<KeyAttestationOptions>;
 
   async createKeyAttestation(
     walletAttestation: CredentialRequestStepOptions["walletAttestation"],
@@ -123,7 +144,7 @@ export class CredentialRequestDefaultStep extends StepFlow {
 
     const provider = new WalletProvider(this.ioWalletSdkConfig);
 
-    return provider.createItKeyAttestationJwt({
+    const defaults: KeyAttestationOptions = {
       attestedKeys: [credentialKeyPair.publicKey],
       callbacks: {
         signJwt: signJwtCallback([providerKey.privateKey]),
@@ -143,7 +164,12 @@ export class CredentialRequestDefaultStep extends StepFlow {
         },
       },
       userAuthentication: ["iso_18045_basic"],
-    });
+    };
+
+    return provider.createItKeyAttestationJwt({
+      ...defaults,
+      ...this.keyAttestationOverrides,
+    } as KeyAttestationOptions);
   }
 
   async run(

--- a/tests/conformance/issuance/credential-validation.issuance.spec.ts
+++ b/tests/conformance/issuance/credential-validation.issuance.spec.ts
@@ -12,6 +12,7 @@ import {
   withCredentialRequestOverrides,
   withCredentialSignJwtOverride,
   withDPoPSignedByWrongKey,
+  withKeyAttestationOverrides,
   withNoAthDPoP,
   withNoDPoP,
   withPrivateKeyInDPoPHeader,
@@ -166,6 +167,51 @@ testConfigs.forEach((testConfig) => {
         walletAttestation: walletAttestationResponse,
       });
     }
+
+    // -----------------------------------------------------------------------
+    // CI_034 — Wallet Key Attestation Security Claims
+    // -----------------------------------------------------------------------
+
+    test("CI_034: Wallet Key Attestation Security Claims | Issuer rejects a credential request whose Wallet Key Attestation does not meet required device security standards", async () => {
+      const log = baseLog.withTag("CI_034");
+      const DESCRIPTION =
+        "Issuer correctly rejected credential request with insufficient Wallet Key Attestation security claims";
+
+      let testSuccess = false;
+      try {
+        if (!ioWalletSdkConfig.isVersion(ItWalletSpecsVersion.V1_3)) {
+          log.debug(
+            "CI_034 skipped: Wallet Key Attestation is only used for v1.3 credential requests",
+          );
+          testSuccess = true;
+          return;
+        }
+
+        log.debug(
+          "→ Sending credential request with non-compliant keyStorage / userAuthentication claims...",
+        );
+        const result = await runCredentialStep(
+          withKeyAttestationOverrides(testConfig.credentialRequestStepClass, {
+            // "software" and "none" are intentionally below the minimum level
+            // required by the Credential Issuer (iso_18045_basic).  These
+            // values bypass the SDK's TypeScript type but are written verbatim
+            // into the signed key attestation JWT — the issuer must reject them.
+            keyStorage: ["software"],
+            userAuthentication: ["none"],
+          }),
+        );
+        log.debug("  Request completed");
+
+        log.debug("→ Validating issuer rejected the request...");
+        expect(
+          result.success,
+          "Issuer should reject a credential request whose Wallet Key Attestation describes a device security posture below the required minimum",
+        ).toBe(false);
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
 
     // -----------------------------------------------------------------------
     // CI_071 — JWT Proof Required Claims

--- a/tests/helpers/credential-validation-helpers.ts
+++ b/tests/helpers/credential-validation-helpers.ts
@@ -13,12 +13,30 @@ import {
   CredentialRequestDefaultStep,
   CredentialRequestResponse,
   CredentialRequestStepOptions,
+  KeyAttestationOptions,
 } from "@/step/issuance/credential-request-step";
 import { KeyPairJwk } from "@/types";
 
 // ---------------------------------------------------------------------------
 // SignJwtCallback factories (credential proof manipulation)
 // ---------------------------------------------------------------------------
+
+/**
+ * Loose override type accepted by `withKeyAttestationOverrides`.
+ *
+ * `keyStorage` and `userAuthentication` intentionally accept arbitrary strings
+ * so that conformance tests can inject non-compliant values (e.g. `"software"`,
+ * `"none"`) without TypeScript errors.  The SDK does not validate these fields
+ * with Zod at runtime — they are embedded verbatim into the signed JWT and
+ * rejected (or accepted) by the Credential Issuer.
+ */
+export type KeyAttestationTestOverrides = Omit<
+  Partial<KeyAttestationOptions>,
+  "keyStorage" | "userAuthentication"
+> & {
+  keyStorage?: [string, ...string[]];
+  userAuthentication?: [string, ...string[]];
+};
 
 /**
  * Returns a SignJwtCallback that signs with HS256 (symmetric algorithm).
@@ -128,6 +146,10 @@ export function signWithWrongKey(): SignJwtCallback {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Step class factory helpers
+// ---------------------------------------------------------------------------
+
 /**
  * Returns a SignJwtCallback that overrides the `typ` header claim.
  * Used for CI_073 (wrong proof type declaration).
@@ -150,10 +172,6 @@ export function signWithWrongTyp(
     return { jwt, signerJwk: realPublicKey as Jwk };
   };
 }
-
-// ---------------------------------------------------------------------------
-// Step class factory helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Wraps a credential request step to send a DPoP proof whose `alg` header
@@ -323,6 +341,27 @@ export function withDPoPSignedByWrongKey(
 
       return super.run({ ...options, dPoPOverride: tamperedDPoP });
     }
+  } as typeof CredentialRequestDefaultStep;
+}
+
+/**
+ * Wraps a credential request step class so that `createKeyAttestation` merges
+ * the supplied overrides over its computed defaults before signing.
+ *
+ * Mirrors `withParOverrides` / `withCredentialRequestOverrides` patterns.
+ * Used for CI_034: verifies that the Issuer rejects a Credential Request whose
+ * Wallet Key Attestation carries insufficient or unsupported security claims.
+ */
+export function withKeyAttestationOverrides(
+  StepClass: typeof CredentialRequestDefaultStep,
+  overrides: KeyAttestationTestOverrides,
+): typeof CredentialRequestDefaultStep {
+  return class extends StepClass {
+    // Cast is safe: the SDK does not perform Zod validation on keyStorage /
+    // userAuthentication at runtime; the values are written directly into the
+    // JWT payload.
+    protected override keyAttestationOverrides =
+      overrides as unknown as Partial<KeyAttestationOptions>;
   } as typeof CredentialRequestDefaultStep;
 }
 
@@ -533,6 +572,10 @@ export function withWrongHtmDPoP(
   } as typeof CredentialRequestDefaultStep;
 }
 
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
 /**
  * Wraps a credential request step to send a DPoP proof whose `htu` claim
  * does not match the credential endpoint URL.
@@ -611,7 +654,7 @@ export function withWrongTypDPoP(
 }
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// Key attestation override helpers (CI_034)
 // ---------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
#### Motivation and Context

This change introduces key attestation overrides to facilitate conformance testing of device security standards. It allows for the submission of non-standard security claim values, enabling verification that the Credential Issuer enforces its security requirements.

#### How Has This Been Tested?

The implementation has been tested through a new conformance test that verifies the issuer's rejection of credential requests with insufficient Wallet Key Attestation security claims. The test checks for compliance with the required device security standards by injecting non-compliant values into the key attestation JWT.

