### PR TITLE
Add --wallet-version CLI option and CONFIG_WALLET_VERSION env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Set it in your `config.ini`:
 wallet_version = V1_3
 ```
 
+Or override it at runtime without editing any file — using the CLI option:
+
+```bash
+wct test:issuance --wallet-version V1_3
+wct test:presentation --wallet-version V1_3
+```
+
+Or via an environment variable:
+
+```bash
+CONFIG_WALLET_VERSION=V1_3 wct test:issuance
+CONFIG_WALLET_VERSION=V1_3 wct test:presentation
+```
+
 > **Tip**: Use `V1_3` when testing against issuers or relying parties that implement the latest specification revision. Use `V1_0` for services that still target the first stable release.
 
 ### TLS Unsafe Mode

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,9 @@ function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   if (options.tests) {
     env.TESTS = options.tests;
   }
+  if (options.walletVersion) {
+    env.CONFIG_WALLET_VERSION = options.walletVersion;
+  }
 
   return env;
 }
@@ -217,6 +220,10 @@ function addCommonOptions(command: Command): Command {
     .option(
       "--tests <names>",
       "Comma separated list of test names, only the specified tests will be run (env: TESTS)",
+    )
+    .option(
+      "--wallet-version <version>",
+      "Override the IT Wallet specification version (V1_0, V1_3) (env: CONFIG_WALLET_VERSION)",
     );
 }
 

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -1,4 +1,7 @@
-import { parseWithErrorHandling } from "@pagopa/io-wallet-utils";
+import {
+  ItWalletSpecsVersion,
+  parseWithErrorHandling,
+} from "@pagopa/io-wallet-utils";
 import { parse } from "ini";
 import { existsSync, readFileSync } from "node:fs";
 import path from "path";
@@ -40,6 +43,7 @@ export interface CliOptions {
   timeout?: number;
   trustAnchorCertDir?: string;
   unsafeTls?: boolean;
+  walletVersion?: string;
 }
 
 interface ConfigLayer {
@@ -198,6 +202,7 @@ function cliOptionsToConfig(options: CliOptions): Partial<Config> {
   const logging = buildLoggingConfig(options);
   const trustAnchor = buildTrustAnchorConfig(options);
   const stepsMapping = buildStepsMappingConfig(options);
+  const wallet = buildWalletConfig(options);
 
   if (hasConfigValues<Config["issuance"]>(issuance)) {
     partialConfig.issuance = issuance as Config["issuance"];
@@ -216,6 +221,9 @@ function cliOptionsToConfig(options: CliOptions): Partial<Config> {
   }
   if (stepsMapping) {
     partialConfig.steps_mapping = stepsMapping;
+  }
+  if (hasConfigValues<Config["wallet"]>(wallet)) {
+    partialConfig.wallet = wallet as Config["wallet"];
   }
 
   return partialConfig;
@@ -391,6 +399,14 @@ const buildTrustAnchorConfig: ConfigSectionBuilder<Config["trust_anchor"]> = (
   }),
 });
 
+const buildWalletConfig: ConfigSectionBuilder<Config["wallet"]> = (
+  options,
+) => ({
+  ...(options.walletVersion && {
+    wallet_version: options.walletVersion as ItWalletSpecsVersion,
+  }),
+});
+
 function buildStepsMappingConfig(
   options: CliOptions,
 ): Config["steps_mapping"] | undefined {
@@ -505,6 +521,7 @@ function readCliOptionsFromEnv(): CliOptions {
   readBooleanEnv(options, "unsafeTls", "CONFIG_UNSAFE_TLS");
   readStringEnv(options, "trustAnchorCertDir", "CONFIG_TRUST_ANCHOR_CERT_DIR");
   readStringEnv(options, "bindAddress", "OIDF_SERVERS_BIND_ADDRESS");
+  readStringEnv(options, "walletVersion", "CONFIG_WALLET_VERSION");
 
   return options;
 }

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -22,6 +22,7 @@ const envKeys = [
   "CONFIG_STEPS_MAPPING",
   "CONFIG_TIMEOUT",
   "CONFIG_UNSAFE_TLS",
+  "CONFIG_WALLET_VERSION",
   "NODE_TLS_REJECT_UNAUTHORIZED",
 ];
 
@@ -109,6 +110,35 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
         "tests/steps/presentation",
       ),
     });
+  });
+
+  it("should override wallet_version from CONFIG_WALLET_VERSION environment variable", () => {
+    process.env.CONFIG_WALLET_VERSION = "V1_3";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.wallet.wallet_version).toBe("V1_3");
+  });
+
+  it("should override wallet_version via direct CliOptions without touching other wallet fields", () => {
+    const config = loadConfigWithHierarchy(
+      { walletVersion: "V1_3" },
+      DEFAULT_INI,
+    );
+
+    expect(config.wallet.wallet_version).toBe("V1_3");
+    expect(config.wallet.wallet_id).toBe("wallet_cli_instance");
+    expect(config.wallet.backup_storage_path).toBe(
+      path.join(packageRoot, "data/backup"),
+    );
+  });
+
+  it("should reject invalid wallet_version values through the config schema", () => {
+    process.env.CONFIG_WALLET_VERSION = "INVALID_VERSION";
+
+    expect(() => loadConfigWithHierarchy(null, DEFAULT_INI)).toThrow(
+      /Configuration validation failed/,
+    );
   });
 });
 


### PR DESCRIPTION
#### Motivation and Context

This change introduces a new CLI option and environment variable to allow users to specify the wallet version at runtime. It addresses the need for flexibility in testing against different wallet specifications without modifying configuration files directly. 
#### How Has This Been Tested?

- Added unit tests to verify the functionality of the new CLI option and environment variable.
- Tested the rejection of invalid wallet version values to ensure configuration validation.
- Confirmed that the new option works seamlessly with existing configurations and does not introduce breaking changes.

