### PR TITLE
fix: align report headings and paragraphs to prototype

### DIFF
--- a/src/report/template/executive-view.ts
+++ b/src/report/template/executive-view.ts
@@ -68,7 +68,7 @@ export function renderExecutiveView(
       ${renderDetailsGrid({ entityName, executedAt, profile, solutionName, specVersion })}
 
       <section aria-labelledby="validation-title">
-        <h2 id="validation-title" class="section-title">Riepilogo Validazione</h2>
+        <h2 id="validation-title" class="section-title">Riepilogo della verifica</h2>
         <div class="metrics" aria-label="Riepilogo dei controlli di validazione">
           <article class="metric-card total">
             <span class="metric-label">Controlli Totali</span>

--- a/src/report/template/shared.ts
+++ b/src/report/template/shared.ts
@@ -191,7 +191,7 @@ export function renderFooter({
       : "";
   return `
     <footer class="footer">
-      <p>Questo rapporto è stato generato automaticamente dallo strumento di conformità IT-Wallet.</p>
+      <p>Questo rapporto è stato generato automaticamente dallo Strumento di Conformità IT-Wallet.</p>
       <p>ID Rapporto: ${escapeHtml(reportId)}</p>
       ${sessionLine}
       <p class="generated">Generato il: ${escapeHtml(generatedAt)}</p>

--- a/src/report/template/technical-view.ts
+++ b/src/report/template/technical-view.ts
@@ -44,7 +44,7 @@ export function renderTechnicalView(
       ${renderDetailsGrid({ entityName, executedAt, profile, solutionName, specVersion })}
 
       <section aria-labelledby="checks-title">
-        <h2 id="checks-title" class="section-title checks-title">Controlli di Conformità Dettagliati</h2>
+        <h2 id="checks-title" class="section-title checks-title">Dettaglio dei controlli di conformità</h2>
         <div class="checks">
           ${checkCards}
         </div>


### PR DESCRIPTION
This pull request makes minor improvements to the wording of section titles and footer text in the report templates to ensure consistency and clarity in the Italian language.

- **Wording improvements in section titles:**
  * Changed the executive summary section title to "Riepilogo della verifica" for improved clarity in `renderExecutiveView` (`src/report/template/executive-view.ts`).
  * Updated the technical view section title to "Dettaglio dei controlli di conformità" for more precise language in `renderTechnicalView` (`src/report/template/technical-view.ts`).

- **Footer text refinement:**
  * Capitalized "Strumento di Conformità IT-Wallet" in the automatically generated report notice for consistency in `renderFooter` (`src/report/template/shared.ts`).