### PR TITLE
Add support for Re-Issuance Flow with DPoP-bound Refresh Token and conformance testing

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -48,6 +48,10 @@ credential_types[] = dc_sd_jwt_EuropeanDisabilityCard
 # The credential_issuer field in the response will override the issuance url. 
 # credential_offer_uri=https://offer.example
 
+# Optional: use a DPoP-bound Refresh Token to run the Re-Issuance Flow instead
+# of the full authorization-code flow. When set, call orchestrator.reissuance().
+# refresh_token = <your-refresh-token>
+
 [presentation]
 # Optional: override the directory where presentation test specs are discovered
 # tests_dir = ./tests/conformance/presentation

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,6 +139,9 @@ function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   if (options.walletVersion) {
     env.CONFIG_WALLET_VERSION = options.walletVersion;
   }
+  if (options.refreshToken) {
+    env.CONFIG_REFRESH_TOKEN = options.refreshToken;
+  }
 
   return env;
 }
@@ -224,6 +227,10 @@ function addCommonOptions(command: Command): Command {
     .option(
       "--wallet-version <version>",
       "Override the IT Wallet specification version (V1_0, V1_3) (env: CONFIG_WALLET_VERSION)",
+    )
+    .option(
+      "--refresh-token <token>",
+      "Use a DPoP-bound Refresh Token to run the Re-Issuance Flow (env: CONFIG_REFRESH_TOKEN)",
     );
 }
 

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -37,6 +37,7 @@ export interface CliOptions {
   port?: number;
   presentationAuthorizeUri?: string;
   presentationTestsDir?: string;
+  refreshToken?: string;
   saveCredential?: boolean;
   stepsMapping?: string;
   tests?: string;
@@ -348,6 +349,7 @@ const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
       .map((t) => t.trim())
       .filter((t) => t.length > 0),
   }),
+  ...(options.refreshToken && { refresh_token: options.refreshToken }),
   ...(options.saveCredential !== undefined && {
     save_credential: options.saveCredential,
   }),
@@ -517,6 +519,7 @@ function readCliOptionsFromEnv(): CliOptions {
     "presentationTestsDir",
     "CONFIG_PRESENTATION_TESTS_DIR",
   );
+  readStringEnv(options, "refreshToken", "CONFIG_REFRESH_TOKEN");
   readStringEnv(options, "stepsMapping", "CONFIG_STEPS_MAPPING");
   readBooleanEnv(options, "unsafeTls", "CONFIG_UNSAFE_TLS");
   readStringEnv(options, "trustAnchorCertDir", "CONFIG_TRUST_ANCHOR_CERT_DIR");

--- a/src/orchestrator/errors.ts
+++ b/src/orchestrator/errors.ts
@@ -52,6 +52,17 @@ export class IssuerMetadataError extends OrchestratorError {
   }
 }
 
+export class ReissuancePreconditionError extends OrchestratorError {
+  constructor() {
+    super(
+      "Re-Issuance Flow requires a refresh token. " +
+        "Set 'refresh_token' under [issuance] in config.ini or pass --refresh-token <token>.",
+      "REISSUANCE_PRECONDITION_FAILED",
+    );
+    this.name = "ReissuancePreconditionError";
+  }
+}
+
 export class StepOutputError extends OrchestratorError {
   readonly missingField: string;
   readonly stepTag: string;

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -20,6 +20,7 @@ import {
   CredentialConfigurationError,
   IssuerMetadataError,
   OrchestratorError,
+  ReissuancePreconditionError,
   StepOutputError,
 } from "@/orchestrator/errors";
 import {
@@ -41,8 +42,11 @@ import {
   AttestationResponse,
   Config,
   IssuanceFlowResponse,
+  KeyPair,
+  ReissuanceFlowResponse,
   RunThroughAuthorizeContext,
   RunThroughParContext,
+  RunThroughRefreshTokenContext,
   RunThroughTokenContext,
 } from "@/types";
 
@@ -195,68 +199,14 @@ export class WalletIssuanceOrchestratorFlow {
       if (!accessToken)
         throw new StepOutputError(TokenRequestDefaultStep.tag, "access_token");
 
-      const entityStatementClaims =
-        fetchMetadataResponse.response?.entityStatementClaims;
-
-      const nonceResponse = await this.nonceRequestStep.run({
-        nonceEndpoint:
-          entityStatementClaims.metadata?.openid_credential_issuer
-            ?.nonce_endpoint,
-      });
-      this._nonceResponse = nonceResponse;
-      this.log.flowStep(
-        5,
-        this.TOTAL_STEPS,
-        "Nonce Request",
-        nonceResponse.success,
-        nonceResponse.durationMs ?? 0,
-      );
-      assertStepSuccess(nonceResponse, "Nonce Request");
-
-      const nonce = nonceResponse.response?.nonce as
-        | undefined
-        | { c_nonce: string };
-      if (!nonce)
-        throw new StepOutputError(NonceRequestDefaultStep.tag, "c_nonce");
-
-      const credentialResponse = await this.credentialRequestStep.run({
-        accessToken,
-        baseUrl: credentialIssuer,
-        clientId: walletAttestationResponse.unitKey.publicKey.kid,
-        credentialIdentifier: this.issuanceConfig.credentialConfigurationId,
-        credentialRequestEndpoint:
-          entityStatementClaims.metadata?.openid_credential_issuer
-            ?.credential_endpoint,
-        dPoPKey,
-        nonce: nonce.c_nonce,
-        walletAttestation: walletAttestationResponse,
-      });
-      this._credentialResponse = credentialResponse;
-      this.log.flowStep(
-        6,
-        this.TOTAL_STEPS,
-        "Credential Request",
-        credentialResponse.success,
-        credentialResponse.durationMs ?? 0,
-      );
-      assertStepSuccess(credentialResponse, "Credential Request");
-
-      // Save credential to disk if configured
-      // Currently, only the first credential is saved because we support requesting one at a time
-      const firstCredential = credentialResponse.response?.credentials?.[0];
-      if (this.config.issuance.save_credential && firstCredential?.credential) {
-        const savedPath = saveCredentialToDisk(
-          this.config.wallet.credentials_storage_path,
-          this.issuanceConfig.credentialConfigurationId,
-          firstCredential.credential,
-          this.config.wallet.wallet_version,
-        );
-        if (savedPath) {
-          this.log.info(`Credential saved to disk: ${savedPath}`);
-        } else {
-          this.log.error("Failed to save credential to disk");
-        }
-      }
+      const { credentialResponse, nonceResponse } =
+        await this.requestCredentialWithToken({
+          accessToken,
+          credentialIssuer,
+          dPoPKey,
+          fetchMetadataResponse,
+          walletAttestationResponse,
+        });
 
       return {
         authorizeResponse,
@@ -278,6 +228,58 @@ export class WalletIssuanceOrchestratorFlow {
         nonceResponse: this._nonceResponse,
         pushedAuthorizationRequestResponse:
           this._pushedAuthorizationRequestResponse,
+        success: false,
+        tokenResponse: this._tokenResponse,
+        walletAttestationResponse: this._walletAttestationResponse,
+      };
+    }
+  }
+
+  async reissuance(): Promise<ReissuanceFlowResponse> {
+    this.resetResponses();
+
+    try {
+      const refreshToken = this.config.issuance.refresh_token;
+      if (!refreshToken) {
+        throw new ReissuancePreconditionError();
+      }
+
+      const {
+        credentialIssuer,
+        dPoPKey,
+        fetchMetadataResponse,
+        tokenResponse,
+        walletAttestationResponse,
+      } = await this.runThroughRefreshToken(refreshToken);
+
+      const accessToken = tokenResponse.response?.access_token;
+      if (!accessToken)
+        throw new StepOutputError(TokenRequestDefaultStep.tag, "access_token");
+
+      const { credentialResponse, nonceResponse } =
+        await this.requestCredentialWithToken({
+          accessToken,
+          credentialIssuer,
+          dPoPKey,
+          fetchMetadataResponse,
+          walletAttestationResponse,
+        });
+
+      return {
+        credentialResponse,
+        fetchMetadataResponse,
+        nonceResponse,
+        success: true,
+        tokenResponse,
+        walletAttestationResponse,
+      };
+    } catch (e) {
+      this.log.error("Error in Re-Issuance Flow!", e);
+      return {
+        credentialResponse: this._credentialResponse,
+        error: e instanceof Error ? e : new Error(String(e)),
+        fetchMetadataResponse: this._fetchMetadataResponse,
+        nonceResponse: this._nonceResponse,
         success: false,
         tokenResponse: this._tokenResponse,
         walletAttestationResponse: this._walletAttestationResponse,
@@ -596,6 +598,92 @@ export class WalletIssuanceOrchestratorFlow {
     );
   }
 
+  /**
+   * Performs the shared Nonce Request → Credential Request → optional save-to-disk
+   * sequence used by both issuance() and reissuance().
+   */
+  private async requestCredentialWithToken({
+    accessToken,
+    credentialIssuer,
+    dPoPKey,
+    fetchMetadataResponse,
+    walletAttestationResponse,
+  }: {
+    accessToken: string;
+    credentialIssuer: string;
+    dPoPKey: KeyPair;
+    fetchMetadataResponse: FetchMetadataStepResponse;
+    walletAttestationResponse: AttestationResponse;
+  }): Promise<{
+    credentialResponse: CredentialRequestResponse;
+    nonceResponse: NonceRequestResponse;
+  }> {
+    const entityStatementClaims =
+      fetchMetadataResponse.response?.entityStatementClaims;
+
+    const nonceResponse = await this.nonceRequestStep.run({
+      nonceEndpoint:
+        entityStatementClaims.metadata?.openid_credential_issuer
+          ?.nonce_endpoint,
+    });
+    this._nonceResponse = nonceResponse;
+    this.log.flowStep(
+      5,
+      this.TOTAL_STEPS,
+      "Nonce Request",
+      nonceResponse.success,
+      nonceResponse.durationMs ?? 0,
+    );
+    assertStepSuccess(nonceResponse, "Nonce Request");
+
+    const nonce = nonceResponse.response?.nonce as
+      | undefined
+      | { c_nonce: string };
+    if (!nonce)
+      throw new StepOutputError(NonceRequestDefaultStep.tag, "c_nonce");
+
+    const credentialResponse = await this.credentialRequestStep.run({
+      accessToken,
+      baseUrl: credentialIssuer,
+      clientId: walletAttestationResponse.unitKey.publicKey.kid,
+      credentialIdentifier: this.issuanceConfig.credentialConfigurationId,
+      credentialRequestEndpoint:
+        entityStatementClaims.metadata?.openid_credential_issuer
+          ?.credential_endpoint,
+      dPoPKey,
+      nonce: nonce.c_nonce,
+      walletAttestation: walletAttestationResponse,
+    });
+    this._credentialResponse = credentialResponse;
+    this.log.flowStep(
+      6,
+      this.TOTAL_STEPS,
+      "Credential Request",
+      credentialResponse.success,
+      credentialResponse.durationMs ?? 0,
+    );
+    assertStepSuccess(credentialResponse, "Credential Request");
+
+    // Save credential to disk if configured
+    // Currently, only the first credential is saved because we support requesting one at a time
+    const firstCredential = credentialResponse.response?.credentials?.[0];
+    if (this.config.issuance.save_credential && firstCredential?.credential) {
+      const savedPath = saveCredentialToDisk(
+        this.config.wallet.credentials_storage_path,
+        this.issuanceConfig.credentialConfigurationId,
+        firstCredential.credential,
+        this.config.wallet.wallet_version,
+      );
+      if (savedPath) {
+        this.log.info(`Credential saved to disk: ${savedPath}`);
+      } else {
+        this.log.error("Failed to save credential to disk");
+      }
+    }
+
+    return { credentialResponse, nonceResponse };
+  }
+
   private resetResponses(): void {
     this._authorizeResponse = undefined;
     this._credentialResponse = undefined;
@@ -604,5 +692,112 @@ export class WalletIssuanceOrchestratorFlow {
     this._pushedAuthorizationRequestResponse = undefined;
     this._tokenResponse = undefined;
     this._walletAttestationResponse = undefined;
+  }
+
+  /**
+   * Executes the Re-Issuance flow from metadata discovery through the
+   * refresh-token token request. Does NOT run PAR or authorization steps.
+   */
+  private async runThroughRefreshToken(
+    refreshToken: string,
+  ): Promise<RunThroughRefreshTokenContext> {
+    this.printTestSuiteOnce();
+    this.log.info("Starting Re-Issuance Flow...");
+
+    const { credentialConfigurationIds, credentialIssuer } =
+      await this.findCredentialConfig();
+
+    this.log.info(
+      `Re-issuing credentials ${JSON.stringify(credentialConfigurationIds)} from issuer ${credentialIssuer}`,
+    );
+
+    const fetchMetadataResponse = await this.fetchMetadataStep.run({
+      baseUrl: credentialIssuer,
+    });
+    this._fetchMetadataResponse = fetchMetadataResponse;
+    this.log.flowStep(
+      1,
+      this.TOTAL_STEPS,
+      "Fetch Metadata",
+      fetchMetadataResponse.success,
+      fetchMetadataResponse.durationMs ?? 0,
+    );
+    assertStepSuccess(fetchMetadataResponse, "Fetch Metadata");
+
+    const walletAttestationResponse = await loadAttestation({
+      trust: this.config.trust,
+      trustAnchor: this.config.trust_anchor,
+      wallet: this.config.wallet,
+    });
+    this._walletAttestationResponse = walletAttestationResponse;
+
+    const callbacks = {
+      ...partialCallbacks,
+      signJwt: signJwtCallback([walletAttestationResponse.unitKey.privateKey]),
+    };
+
+    const entityStatementClaims =
+      fetchMetadataResponse.response?.entityStatementClaims;
+    if (!entityStatementClaims) {
+      throw new OrchestratorError(
+        "Fetch Metadata step returned no entity statement claims.",
+        "ENTITY_STATEMENT_CLAIMS_MISSING",
+      );
+    }
+
+    const popAttestation = await createClientAttestationPopJwt({
+      authorizationServer: credentialIssuer,
+      callbacks,
+      clientAttestation: walletAttestationResponse.attestation,
+      config: new IoWalletSdkConfig({
+        itWalletSpecsVersion: this.config.wallet.wallet_version,
+      }),
+      jti: randomUUID(),
+    });
+
+    const tokenEndpoint =
+      entityStatementClaims.metadata?.oauth_authorization_server
+        ?.token_endpoint;
+    if (!tokenEndpoint) {
+      throw new IssuerMetadataError(
+        "token_endpoint",
+        "oauth_authorization_server",
+        "Re-Issuance Token Request",
+      );
+    }
+
+    // refresh_token is guaranteed non-null here — passed from reissuance()
+    // after a null-check guard.
+    const accessTokenRequest: AccessTokenRequest = {
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    };
+
+    const tokenResponse = await this.tokenRequestStep.run({
+      accessTokenEndpoint: tokenEndpoint,
+      accessTokenRequest,
+      popAttestation,
+      walletAttestation: walletAttestationResponse,
+    });
+    this._tokenResponse = tokenResponse;
+    this.log.flowStep(
+      4,
+      this.TOTAL_STEPS,
+      "Re-Issuance Token Request",
+      tokenResponse.success,
+      tokenResponse.durationMs ?? 0,
+    );
+    assertStepSuccess(tokenResponse, "Re-Issuance Token Request");
+
+    const dPoPKey = tokenResponse.response?.dPoPKey;
+    if (!dPoPKey) throw new StepOutputError("TOKEN_REQUEST", "dPoPKey");
+
+    return {
+      credentialIssuer,
+      dPoPKey,
+      fetchMetadataResponse,
+      tokenResponse,
+      walletAttestationResponse,
+    };
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -25,6 +25,7 @@ export const configSchema = z.object({
       .or(z.string().startsWith("openid-credential-offer://"))
       .optional(),
     credential_types: z.array(z.string()).optional().default([]),
+    refresh_token: z.string().optional(),
     save_credential: zBooleanFromString.optional().default(false),
     tests_dir: z.string().default("./tests/issuance"),
     url: z.string().url(),

--- a/src/types/issuance-orchestrator-context.ts
+++ b/src/types/issuance-orchestrator-context.ts
@@ -22,6 +22,16 @@ export interface IssuanceFlowResponse {
   walletAttestationResponse?: AttestationResponse;
 }
 
+export interface ReissuanceFlowResponse {
+  credentialResponse?: CredentialRequestResponse;
+  error?: Error;
+  fetchMetadataResponse?: FetchMetadataStepResponse;
+  nonceResponse?: NonceRequestResponse;
+  success: boolean;
+  tokenResponse?: TokenRequestResponse;
+  walletAttestationResponse?: AttestationResponse;
+}
+
 export type RunThroughAuthorizeContext = RunThroughParContext & {
   authorizationEndpoint: string;
   authorizeResponse: AuthorizeStepResponse;
@@ -34,6 +44,14 @@ export interface RunThroughParContext {
   popAttestation: string;
   pushedAuthorizationRequestEndpoint: string;
   pushedAuthorizationRequestResponse: PushedAuthorizationRequestResponse;
+  walletAttestationResponse: AttestationResponse;
+}
+
+export interface RunThroughRefreshTokenContext {
+  credentialIssuer: string;
+  dPoPKey: KeyPair;
+  fetchMetadataResponse: FetchMetadataStepResponse;
+  tokenResponse: TokenRequestResponse;
   walletAttestationResponse: AttestationResponse;
 }
 

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -10,6 +10,10 @@ import {
   withRefreshTokenDPoPSignedByWrongKey,
 } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
 import { calculateJwkThumbprint, decodeJwt } from "jose";
 import { beforeAll, describe, expect, test } from "vitest";
 
@@ -19,12 +23,17 @@ import type {
 } from "@/step/issuance";
 import type { KeyPair } from "@/types";
 
+import { loadConfigWithHierarchy } from "@/logic";
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
 
 const testConfigs = await defineIssuanceTest("RefreshTokenIssuance");
 
+const isV1_0 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: loadConfigWithHierarchy().wallet.wallet_version,
+}).isVersion(ItWalletSpecsVersion.V1_0);
+
 testConfigs.forEach((testConfig) => {
-  describe(`[${testConfig.name}] Refresh Token Issuance`, () => {
+  describe.skipIf(isV1_0)(`[${testConfig.name}] Refresh Token Issuance`, () => {
     let capturedCredentialRequestDPoPKey: KeyPair | undefined;
 
     class CapturingCredentialRequestStep

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -9,7 +9,7 @@ import {
   withRefreshTokenDPoPSignedByWrongKey,
 } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
-import { calculateJwkThumbprint } from "jose";
+import { calculateJwkThumbprint, decodeJwt } from "jose";
 import { beforeAll, describe, expect, test } from "vitest";
 
 import type {
@@ -348,6 +348,50 @@ testConfigs.forEach((testConfig) => {
           new Set(issuedRefreshToken).size,
           "Refresh token has too little character variety",
         ).toBeGreaterThan(8);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_104: Refresh Token Duration | Issuer time-limits refresh tokens to at most one year", async () => {
+      const log = baseLog.withTag("CI_104");
+      const DESCRIPTION =
+        "Refresh token lifetime is bounded and does not exceed one year";
+
+      const maxRefreshTokenLifetimeSeconds = 365 * 24 * 60 * 60;
+
+      let testSuccess = false;
+      try {
+        expect(issuedRefreshToken, "Refresh token is undefined").toBeDefined();
+        if (!issuedRefreshToken) {
+          throw new Error("Refresh token is undefined");
+        }
+
+        const claims = decodeJwt(issuedRefreshToken);
+
+        expect(
+          typeof claims.iat,
+          "Refresh token must expose issued-at time",
+        ).toBe("number");
+        expect(
+          typeof claims.exp,
+          "Refresh token must expose expiration time",
+        ).toBe("number");
+
+        if (typeof claims.iat !== "number" || typeof claims.exp !== "number") {
+          throw new Error("Refresh token lifetime claims are not numeric");
+        }
+
+        expect(
+          claims.exp,
+          "Refresh token expiration must be after issued-at",
+        ).toBeGreaterThan(claims.iat);
+        expect(
+          claims.exp - claims.iat,
+          "Refresh token lifetime must not exceed one year",
+        ).toBeLessThanOrEqual(maxRefreshTokenLifetimeSeconds);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -23,6 +23,7 @@ testConfigs.forEach((testConfig) => {
 
     let credentialResponse: CredentialRequestResponse;
     let refreshTokenTokenEndpoint: string | undefined;
+    let issuedRefreshToken: string | undefined;
 
     beforeAll(async () => {
       try {
@@ -33,6 +34,7 @@ testConfigs.forEach((testConfig) => {
         refreshTokenTokenEndpoint =
           result.fetchMetadataResponse.response?.entityStatementClaims?.metadata
             ?.oauth_authorization_server?.token_endpoint;
+        issuedRefreshToken = result.tokenResponse.response?.refresh_token;
 
         baseLog.info("Re-issuance flow completed successfully");
       } catch (e) {
@@ -213,6 +215,36 @@ testConfigs.forEach((testConfig) => {
           new URL(refreshTokenTokenEndpoint).protocol,
           "Token endpoint must use HTTPS",
         ).toBe("https:");
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_099: Refresh Token Security | Refresh tokens are generated with unguessable values and protected from modification", async () => {
+      const log = baseLog.withTag("CI_099");
+      const DESCRIPTION =
+        "Refresh tokens are generated with unguessable values and modification protection";
+
+      let testSuccess = false;
+      try {
+        expect(issuedRefreshToken, "Refresh token is undefined").toBeDefined();
+        if (!issuedRefreshToken) {
+          throw new Error("Refresh token is undefined");
+        }
+        expect(
+          issuedRefreshToken,
+          "Issuer reused the input refresh token instead of generating a new one",
+        ).not.toBe(orchestrator.getConfig().issuance.refresh_token);
+        expect(
+          issuedRefreshToken.length,
+          "Refresh token must have at least 128 bits of encoded entropy",
+        ).toBeGreaterThanOrEqual(22);
+        expect(
+          new Set(issuedRefreshToken).size,
+          "Refresh token has too little character variety",
+        ).toBeGreaterThan(8);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -5,6 +5,7 @@ import {
   extractTokenError,
   withInvalidClientAttestationPop,
   withInvalidRefreshTokenDPoP,
+  withMissingRefreshTokenDPoP,
   withRefreshTokenDPoPSignedByWrongKey,
 } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
@@ -155,6 +156,37 @@ testConfigs.forEach((testConfig) => {
         expect(
           result.tokenResponse?.success,
           "Token request did not fail; rejection may have happened outside refresh-token DPoP binding validation",
+        ).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_102: DPoP Proof JWT | DPoP Proof is required for all refresh token operations to obtain new Access Tokens", async () => {
+      const log = baseLog.withTag("CI_102");
+      const DESCRIPTION =
+        "Issuer correctly rejected refresh-token reissuance with missing DPoP proof";
+
+      let testSuccess = false;
+      try {
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow({
+          ...testConfig,
+          tokenRequestStepClass: withMissingRefreshTokenDPoP(
+            testConfig.tokenRequestStepClass,
+          ),
+        });
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.success,
+          "Re-issuance flow succeeded despite missing DPoP proof",
+        ).toBe(false);
+        expect(
+          result.tokenResponse?.success,
+          "Token request did not fail; rejection may have happened outside token endpoint DPoP validation",
         ).toBe(false);
 
         testSuccess = true;

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -3,6 +3,7 @@ import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
 import {
   withInvalidClientAttestationPop,
   withInvalidRefreshTokenDPoP,
+  withRefreshTokenDPoPSignedByWrongKey,
 } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
 import { beforeAll, describe, expect, test } from "vitest";
@@ -115,6 +116,37 @@ testConfigs.forEach((testConfig) => {
         expect(
           result.tokenResponse?.success,
           "Token request did not fail; rejection may have happened outside token endpoint DPoP validation",
+        ).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_093: Refresh Token Binding | Issuer rejects a refresh-token reissuance request when DPoP proof key differs from the Refresh Token binding key", async () => {
+      const log = baseLog.withTag("CI_093");
+      const DESCRIPTION =
+        "Issuer correctly rejected refresh-token reissuance with DPoP key not bound to the Refresh Token";
+
+      let testSuccess = false;
+      try {
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow({
+          ...testConfig,
+          tokenRequestStepClass: withRefreshTokenDPoPSignedByWrongKey(
+            testConfig.tokenRequestStepClass,
+          ),
+        });
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.success,
+          "Re-issuance flow succeeded despite DPoP key not matching Refresh Token binding",
+        ).toBe(false);
+        expect(
+          result.tokenResponse?.success,
+          "Token request did not fail; rejection may have happened outside refresh-token DPoP binding validation",
         ).toBe(false);
 
         testSuccess = true;

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -9,9 +9,14 @@ import {
   withRefreshTokenDPoPSignedByWrongKey,
 } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
+import { calculateJwkThumbprint } from "jose";
 import { beforeAll, describe, expect, test } from "vitest";
 
-import type { CredentialRequestResponse } from "@/step/issuance";
+import type {
+  CredentialRequestResponse,
+  CredentialRequestStepOptions,
+} from "@/step/issuance";
+import type { KeyPair } from "@/types";
 
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
 
@@ -19,12 +24,29 @@ const testConfigs = await defineIssuanceTest("RefreshTokenIssuance");
 
 testConfigs.forEach((testConfig) => {
   describe(`[${testConfig.name}] Refresh Token Issuance`, () => {
-    const orchestrator = new WalletIssuanceOrchestratorFlow(testConfig);
+    let capturedCredentialRequestDPoPKey: KeyPair | undefined;
+
+    class CapturingCredentialRequestStep
+      extends testConfig.credentialRequestStepClass
+    {
+      async run(
+        options: CredentialRequestStepOptions,
+      ): Promise<CredentialRequestResponse> {
+        capturedCredentialRequestDPoPKey = options.dPoPKey;
+        return super.run(options);
+      }
+    }
+
+    const orchestrator = new WalletIssuanceOrchestratorFlow({
+      ...testConfig,
+      credentialRequestStepClass: CapturingCredentialRequestStep,
+    });
     const baseLog = orchestrator.getLog();
 
     let credentialResponse: CredentialRequestResponse;
     let refreshTokenTokenEndpoint: string | undefined;
     let issuedRefreshToken: string | undefined;
+    let refreshTokenDPoPKey: KeyPair | undefined;
 
     beforeAll(async () => {
       try {
@@ -36,6 +58,7 @@ testConfigs.forEach((testConfig) => {
           result.fetchMetadataResponse.response?.entityStatementClaims?.metadata
             ?.oauth_authorization_server?.token_endpoint;
         issuedRefreshToken = result.tokenResponse.response?.refresh_token;
+        refreshTokenDPoPKey = result.tokenResponse.response?.dPoPKey;
 
         baseLog.info("Re-issuance flow completed successfully");
       } catch (e) {
@@ -188,6 +211,54 @@ testConfigs.forEach((testConfig) => {
           result.tokenResponse?.success,
           "Token request did not fail; rejection may have happened outside token endpoint DPoP validation",
         ).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_103: DPoP Proof JWT | Credential Request DPoP proof reuses the DPoP key generated during refresh-token Token Request", async () => {
+      const log = baseLog.withTag("CI_103");
+      const DESCRIPTION =
+        "Credential Request DPoP proof reuses the refresh-token Token Request DPoP key";
+
+      let testSuccess = false;
+      try {
+        expect(
+          refreshTokenDPoPKey,
+          "Refresh-token Token Request DPoP key is undefined",
+        ).toBeDefined();
+        expect(
+          credentialResponse.success,
+          "Credential request step failed",
+        ).toBe(true);
+        expect(
+          credentialResponse.response,
+          "Credential response body is undefined",
+        ).toBeDefined();
+        expect(
+          capturedCredentialRequestDPoPKey,
+          "Credential Request DPoP key was not captured",
+        ).toBeDefined();
+
+        if (!refreshTokenDPoPKey || !capturedCredentialRequestDPoPKey) {
+          throw new Error(
+            "Cannot compare DPoP key thumbprints because a DPoP key is undefined",
+          );
+        }
+
+        const tokenDPoPJkt = await calculateJwkThumbprint(
+          refreshTokenDPoPKey.publicKey,
+        );
+        const credentialRequestDPoPJkt = await calculateJwkThumbprint(
+          capturedCredentialRequestDPoPKey.publicKey,
+        );
+
+        expect(
+          credentialRequestDPoPJkt,
+          "Credential Request DPoP key thumbprint does not match the refresh-token Token Request DPoP key",
+        ).toBe(tokenDPoPJkt);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,6 +1,7 @@
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
 import {
+  extractTokenError,
   withInvalidClientAttestationPop,
   withInvalidRefreshTokenDPoP,
   withRefreshTokenDPoPSignedByWrongKey,
@@ -148,6 +149,40 @@ testConfigs.forEach((testConfig) => {
           result.tokenResponse?.success,
           "Token request did not fail; rejection may have happened outside refresh-token DPoP binding validation",
         ).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_096: Refresh Token Validation | Issuer rejects expired or invalid Refresh Token with invalid_grant", async () => {
+      const log = baseLog.withTag("CI_096");
+      const DESCRIPTION =
+        "Issuer correctly rejected expired or invalid Refresh Token with invalid_grant";
+
+      let testSuccess = false;
+      try {
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow(
+          testConfig,
+        );
+        negativeOrchestrator.getConfig().issuance.refresh_token =
+          "invalid-refresh-token-ci-096";
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.success,
+          "Re-issuance flow succeeded despite invalid Refresh Token",
+        ).toBe(false);
+        expect(
+          result.tokenResponse?.success,
+          "Token request did not fail; rejection may have happened outside token endpoint validation",
+        ).toBe(false);
+        expect(
+          extractTokenError(result.tokenResponse),
+          "Issuer did not return the expected OAuth error type 'invalid_grant' for an invalid Refresh Token",
+        ).toBe("invalid_grant");
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
 import {
@@ -21,6 +22,7 @@ testConfigs.forEach((testConfig) => {
     const baseLog = orchestrator.getLog();
 
     let credentialResponse: CredentialRequestResponse;
+    let refreshTokenTokenEndpoint: string | undefined;
 
     beforeAll(async () => {
       try {
@@ -28,6 +30,9 @@ testConfigs.forEach((testConfig) => {
         assertReissuanceFlowSuccess(result);
 
         credentialResponse = result.credentialResponse;
+        refreshTokenTokenEndpoint =
+          result.fetchMetadataResponse.response?.entityStatementClaims?.metadata
+            ?.oauth_authorization_server?.token_endpoint;
 
         baseLog.info("Re-issuance flow completed successfully");
       } catch (e) {
@@ -183,6 +188,31 @@ testConfigs.forEach((testConfig) => {
           extractTokenError(result.tokenResponse),
           "Issuer did not return the expected OAuth error type 'invalid_grant' for an invalid Refresh Token",
         ).toBe("invalid_grant");
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_098: Token Transmission Security | Refresh-token token endpoint uses TLS-protected HTTPS", async () => {
+      const log = baseLog.withTag("CI_098");
+      const DESCRIPTION =
+        "Refresh-token token endpoint uses a TLS-protected HTTPS connection";
+
+      let testSuccess = false;
+      try {
+        expect(
+          refreshTokenTokenEndpoint,
+          "Token endpoint is undefined",
+        ).toBeDefined();
+        if (!refreshTokenTokenEndpoint) {
+          throw new Error("Token endpoint is undefined");
+        }
+        expect(
+          new URL(refreshTokenTokenEndpoint).protocol,
+          "Token endpoint must use HTTPS",
+        ).toBe("https:");
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines-per-function */
 import { defineIssuanceTest } from "#/config/test-metadata";
+import { withCredentialRequestOverrides } from "#/helpers/credential-validation-helpers";
 import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
 import {
   extractTokenError,
@@ -87,6 +88,73 @@ testConfigs.forEach((testConfig) => {
           credentialResponse.response,
           "Credential response body is undefined",
         ).toBeDefined();
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_114: Refresh Token Security | Issuer rejects first-time issuance with an Access Token obtained through Refresh Token flow", async () => {
+      const log = baseLog.withTag("CI_114");
+      const DESCRIPTION =
+        "Issuer correctly rejected first-time issuance with a refresh-token Access Token";
+
+      let testSuccess = false;
+      try {
+        const firstTimeCredentialConfigurationId = testConfigs.find(
+          ({ credentialConfigurationId }) =>
+            credentialConfigurationId !== testConfig.credentialConfigurationId,
+        )?.credentialConfigurationId;
+
+        if (!firstTimeCredentialConfigurationId) {
+          log.debug(
+            "CI_114 skipped: no alternate configured credential type is available to model first-time issuance",
+          );
+          testSuccess = true;
+          return;
+        }
+
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow({
+          ...testConfig,
+          credentialRequestStepClass: withCredentialRequestOverrides(
+            testConfig.credentialRequestStepClass,
+            {
+              credential_identifier: firstTimeCredentialConfigurationId,
+            },
+          ),
+        });
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.fetchMetadataResponse?.success,
+          "Metadata discovery failed before the first-time issuance Credential Request",
+        ).toBe(true);
+        expect(
+          result.tokenResponse?.success,
+          "Refresh-token Token Request failed before the first-time issuance Credential Request",
+        ).toBe(true);
+        expect(
+          result.tokenResponse?.response?.access_token,
+          "Refresh-token Token Request did not return an Access Token",
+        ).toBeDefined();
+        expect(
+          result.nonceResponse?.success,
+          "Nonce Request failed before the first-time issuance Credential Request",
+        ).toBe(true);
+        expect(
+          result.success,
+          "Re-issuance flow succeeded even though the refresh-token Access Token was used for first-time issuance",
+        ).toBe(false);
+        expect(
+          result.credentialResponse,
+          "Credential Request result is undefined; rejection did not happen at the Credential endpoint",
+        ).toBeDefined();
+        expect(
+          result.credentialResponse?.success,
+          `Issuer accepted first-time issuance for credential '${firstTimeCredentialConfigurationId}' using a refresh-token Access Token bound to '${testConfig.credentialConfigurationId}'`,
+        ).toBe(false);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,11 +1,10 @@
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
+import { withInvalidClientAttestationPop } from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
 import { beforeAll, describe, expect, test } from "vitest";
 
-import type {
-  CredentialRequestResponse,
-} from "@/step/issuance";
+import type { CredentialRequestResponse } from "@/step/issuance";
 
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
 
@@ -52,6 +51,37 @@ testConfigs.forEach((testConfig) => {
           credentialResponse.response,
           "Credential response body is undefined",
         ).toBeDefined();
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_091: OAuth-Client-Attestation-PoP Validation | Issuer rejects a refresh-token reissuance request with invalid OAuth-Client-Attestation-PoP", async () => {
+      const log = baseLog.withTag("CI_091");
+      const DESCRIPTION =
+        "Issuer correctly rejected refresh-token reissuance with invalid OAuth-Client-Attestation-PoP";
+
+      let testSuccess = false;
+      try {
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow({
+          ...testConfig,
+          tokenRequestStepClass: withInvalidClientAttestationPop(
+            testConfig.tokenRequestStepClass,
+          ),
+        });
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.success,
+          "Re-issuance flow succeeded despite invalid OAuth-Client-Attestation-PoP",
+        ).toBe(false);
+        expect(
+          result.tokenResponse?.success,
+          "Token request did not fail; rejection may have happened outside token endpoint validation",
+        ).toBe(false);
 
         testSuccess = true;
       } finally {

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,6 +1,9 @@
 import { defineIssuanceTest } from "#/config/test-metadata";
 import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
-import { withInvalidClientAttestationPop } from "#/helpers/refresh-token-validation-helpers";
+import {
+  withInvalidClientAttestationPop,
+  withInvalidRefreshTokenDPoP,
+} from "#/helpers/refresh-token-validation-helpers";
 import { useTestSummary } from "#/helpers/use-test-summary";
 import { beforeAll, describe, expect, test } from "vitest";
 
@@ -81,6 +84,37 @@ testConfigs.forEach((testConfig) => {
         expect(
           result.tokenResponse?.success,
           "Token request did not fail; rejection may have happened outside token endpoint validation",
+        ).toBe(false);
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+
+    test("CI_092: DPoP Proof JWT | Issuer rejects a refresh-token reissuance request with invalid DPoP proof", async () => {
+      const log = baseLog.withTag("CI_092");
+      const DESCRIPTION =
+        "Issuer correctly rejected refresh-token reissuance with invalid DPoP proof";
+
+      let testSuccess = false;
+      try {
+        const negativeOrchestrator = new WalletIssuanceOrchestratorFlow({
+          ...testConfig,
+          tokenRequestStepClass: withInvalidRefreshTokenDPoP(
+            testConfig.tokenRequestStepClass,
+          ),
+        });
+
+        const result = await negativeOrchestrator.reissuance();
+
+        expect(
+          result.success,
+          "Re-issuance flow succeeded despite invalid DPoP proof",
+        ).toBe(false);
+        expect(
+          result.tokenResponse?.success,
+          "Token request did not fail; rejection may have happened outside token endpoint DPoP validation",
         ).toBe(false);
 
         testSuccess = true;

--- a/tests/conformance/issuance/refresh-token.issuance.spec.ts
+++ b/tests/conformance/issuance/refresh-token.issuance.spec.ts
@@ -1,0 +1,62 @@
+import { defineIssuanceTest } from "#/config/test-metadata";
+import { assertReissuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
+import { useTestSummary } from "#/helpers/use-test-summary";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import type {
+  CredentialRequestResponse,
+} from "@/step/issuance";
+
+import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
+
+const testConfigs = await defineIssuanceTest("RefreshTokenIssuance");
+
+testConfigs.forEach((testConfig) => {
+  describe(`[${testConfig.name}] Refresh Token Issuance`, () => {
+    const orchestrator = new WalletIssuanceOrchestratorFlow(testConfig);
+    const baseLog = orchestrator.getLog();
+
+    let credentialResponse: CredentialRequestResponse;
+
+    beforeAll(async () => {
+      try {
+        const result = await orchestrator.reissuance();
+        assertReissuanceFlowSuccess(result);
+
+        credentialResponse = result.credentialResponse;
+
+        baseLog.info("Re-issuance flow completed successfully");
+      } catch (e) {
+        baseLog.error(e);
+        throw e;
+      } finally {
+        // Give time for all logs to be flushed before starting tests
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    });
+
+    useTestSummary(baseLog, testConfig.name);
+
+    test("CI_088: Refresh Token Issuance | Access Token obtained through a Refresh Token flow is successfully used for Credential endpoint", async () => {
+      const log = baseLog.withTag("CI_088");
+      const DESCRIPTION =
+        "Access token obtained through refresh token flow successfully used for Credential endpoint";
+
+      let testSuccess = false;
+      try {
+        expect(
+          credentialResponse.success,
+          "Credential request step failed",
+        ).toBe(true);
+        expect(
+          credentialResponse.response,
+          "Credential response body is undefined",
+        ).toBeDefined();
+
+        testSuccess = true;
+      } finally {
+        log.testCompleted(DESCRIPTION, testSuccess);
+      }
+    });
+  });
+});

--- a/tests/helpers/flow-assertion-helpers.ts
+++ b/tests/helpers/flow-assertion-helpers.ts
@@ -1,4 +1,4 @@
-import type { IssuanceFlowResponse } from "@/types";
+import type { IssuanceFlowResponse, ReissuanceFlowResponse } from "@/types";
 import type { PresentationFlowResponse } from "@/types";
 
 /**
@@ -29,6 +29,22 @@ export function assertPresentationFlowSuccess(
   if (!result.success) {
     throw new Error(
       `Presentation flow failed: ${result.error?.message ?? "unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Asserts that a re-issuance flow completed successfully.
+ * Narrows the type so all step responses are non-optional.
+ */
+export function assertReissuanceFlowSuccess(
+  result: ReissuanceFlowResponse,
+): asserts result is Required<Omit<ReissuanceFlowResponse, "error">> & {
+  success: true;
+} {
+  if (!result.success) {
+    throw new Error(
+      `Re-issuance flow failed: ${result.error?.message ?? "unknown error"}`,
     );
   }
 }

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from "./http-helpers";
 export * from "./par-validation-helpers";
+export * from "./refresh-token-validation-helpers";
 export * from "./shared-helpers";
 export * from "./token-validation-helpers";

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -1,0 +1,31 @@
+import { buildTamperedPopJwt } from "#/helpers/par-validation-helpers";
+
+import type {
+  TokenRequestResponse,
+  TokenRequestStepOptions,
+} from "@/step/issuance";
+
+import { TokenRequestDefaultStep } from "@/step/issuance";
+
+const wrongClientAttestationPopAudience = "https://attacker.example.com";
+
+export function withInvalidClientAttestationPop(
+  StepClass: typeof TokenRequestDefaultStep,
+): typeof TokenRequestDefaultStep {
+  return class extends StepClass {
+    async run(options: TokenRequestStepOptions): Promise<TokenRequestResponse> {
+      const invalidPop = await buildTamperedPopJwt({
+        authorizationServer: options.accessTokenEndpoint,
+        clientAttestation: options.walletAttestation.attestation,
+        config: this.ioWalletSdkConfig,
+        realUnitKey: options.walletAttestation.unitKey.privateKey,
+        wrongAud: wrongClientAttestationPopAudience,
+      });
+
+      return super.run({
+        ...options,
+        popAttestation: invalidPop,
+      });
+    }
+  } as typeof TokenRequestDefaultStep;
+}

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -1,10 +1,12 @@
 import { buildTamperedPopJwt } from "#/helpers/par-validation-helpers";
+import { createTokenDPoP } from "@pagopa/io-wallet-oauth2";
 
 import type {
   TokenRequestResponse,
   TokenRequestStepOptions,
 } from "@/step/issuance";
 
+import { partialCallbacks, signJwtCallback } from "@/logic";
 import { TokenRequestDefaultStep } from "@/step/issuance";
 
 const wrongClientAttestationPopAudience = "https://attacker.example.com";
@@ -25,6 +27,43 @@ export function withInvalidClientAttestationPop(
       return super.run({
         ...options,
         popAttestation: invalidPop,
+      });
+    }
+  } as typeof TokenRequestDefaultStep;
+}
+
+/**
+ * Wraps a token request step class to send a DPoP proof with `htm = "GET"`
+ * (wrong HTTP method) while keeping a valid cryptographic signature.
+ *
+ * Used for CI_092: issuer MUST reject the refresh-token reissuance request
+ * because the DPoP proof does not match the token endpoint method (RFC 9449 §4.3).
+ */
+export function withInvalidRefreshTokenDPoP(
+  StepClass: typeof TokenRequestDefaultStep,
+): typeof TokenRequestDefaultStep {
+  return class extends StepClass {
+    async run(options: TokenRequestStepOptions): Promise<TokenRequestResponse> {
+      const { unitKey } = options.walletAttestation;
+      const invalidDpop = await createTokenDPoP({
+        callbacks: {
+          ...partialCallbacks,
+          signJwt: signJwtCallback([unitKey.privateKey]),
+        },
+        signer: {
+          alg: "ES256",
+          method: "jwk",
+          publicJwk: unitKey.publicKey,
+        },
+        tokenRequest: {
+          method: "GET", // wrong method → htm = "GET" instead of "POST"
+          url: options.accessTokenEndpoint,
+        },
+      });
+
+      return super.run({
+        ...options,
+        dpopProof: invalidDpop,
       });
     }
   } as typeof TokenRequestDefaultStep;

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -1,5 +1,7 @@
 import { buildTamperedPopJwt } from "#/helpers/par-validation-helpers";
-import { createTokenDPoP } from "@pagopa/io-wallet-oauth2";
+import { createTokenDPoP, Jwk, JwtSignerJwk } from "@pagopa/io-wallet-oauth2";
+import { exportJWK, generateKeyPair } from "jose";
+import { randomUUID } from "node:crypto";
 
 import type {
   TokenRequestResponse,
@@ -8,6 +10,7 @@ import type {
 
 import { partialCallbacks, signJwtCallback } from "@/logic";
 import { TokenRequestDefaultStep } from "@/step/issuance";
+import { KeyPairJwk } from "@/types";
 
 const wrongClientAttestationPopAudience = "https://attacker.example.com";
 
@@ -64,6 +67,54 @@ export function withInvalidRefreshTokenDPoP(
       return super.run({
         ...options,
         dpopProof: invalidDpop,
+      });
+    }
+  } as typeof TokenRequestDefaultStep;
+}
+
+/**
+ * Wraps a token request step class to send a valid DPoP proof for the token
+ * endpoint, but signed with a fresh key that is unrelated to the key bound to
+ * the Refresh Token.
+ *
+ * Used for CI_093: the issuer MUST reject the refresh-token reissuance request
+ * because the DPoP proof key thumbprint does not match the Refresh Token
+ * confirmation binding.
+ */
+export function withRefreshTokenDPoPSignedByWrongKey(
+  StepClass: typeof TokenRequestDefaultStep,
+): typeof TokenRequestDefaultStep {
+  return class extends StepClass {
+    async run(options: TokenRequestStepOptions): Promise<TokenRequestResponse> {
+      const { privateKey: wrongPrivate, publicKey: wrongPublic } =
+        await generateKeyPair("ES256", { extractable: true });
+      const wrongPrivateJwk = await exportJWK(wrongPrivate);
+      const wrongPublicJwk = await exportJWK(wrongPublic);
+      const wrongKid = randomUUID();
+
+      const wrongSigner: JwtSignerJwk = {
+        alg: "ES256",
+        method: "jwk",
+        publicJwk: { ...wrongPublicJwk, kid: wrongKid, kty: "EC" } as Jwk,
+      };
+
+      const wrongKeyDpop = await createTokenDPoP({
+        callbacks: {
+          ...partialCallbacks,
+          signJwt: signJwtCallback([
+            { ...wrongPrivateJwk, kid: wrongKid, kty: "EC" } as KeyPairJwk,
+          ]),
+        },
+        signer: wrongSigner,
+        tokenRequest: {
+          method: "POST" as const,
+          url: options.accessTokenEndpoint,
+        },
+      });
+
+      return super.run({
+        ...options,
+        dpopProof: wrongKeyDpop,
       });
     }
   } as typeof TokenRequestDefaultStep;

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -16,6 +16,17 @@ import { KeyPairJwk } from "@/types";
 
 const wrongClientAttestationPopAudience = "https://attacker.example.com";
 
+/**
+ * Returns a copy of `token` with its last character changed.
+ * Length is preserved so the tampered value targets modification-integrity
+ * protection rather than length or format validation.
+ */
+export function tamperTokenValue(token: string): string {
+  const index = token.length - 1;
+  const replacement = token[index] === "A" ? "B" : "A";
+  return `${token.slice(0, index)}${replacement}`;
+}
+
 export function withInvalidClientAttestationPop(
   StepClass: typeof TokenRequestDefaultStep,
 ): typeof TokenRequestDefaultStep {

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -34,6 +34,9 @@ const wrongClientAttestationPopAudience = "https://attacker.example.com";
  * protection rather than length or format validation.
  */
 export function tamperTokenValue(token: string): string {
+  if (token.length === 0) {
+    return token;
+  }
   const index = token.length - 1;
   const replacement = token[index] === "A" ? "B" : "A";
   return `${token.slice(0, index)}${replacement}`;

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -1,7 +1,9 @@
 import { buildTamperedPopJwt } from "#/helpers/par-validation-helpers";
 import { createTokenDPoP, Jwk, JwtSignerJwk } from "@pagopa/io-wallet-oauth2";
+import { UnexpectedStatusCodeError } from "@pagopa/io-wallet-utils";
 import { exportJWK, generateKeyPair } from "jose";
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 
 import type {
   TokenRequestResponse,
@@ -118,4 +120,42 @@ export function withRefreshTokenDPoPSignedByWrongKey(
       });
     }
   } as typeof TokenRequestDefaultStep;
+}
+
+const oauthErrorBodySchema = z.object({ error: z.string() }).passthrough();
+
+/**
+ * Extracts the OAuth `error` field from a failed token request response.
+ *
+ * When the token endpoint returns a non-200 status, `fetchTokenResponse` throws
+ * an `UnexpectedStatusCodeError` whose `reason` property contains the raw
+ * response body (JSON string).  This helper narrows the error type, parses the
+ * body, and returns the `error` member so tests can assert on it without using
+ * `any`.
+ *
+ * Returns `undefined` when:
+ * - the response is undefined or succeeded
+ * - the error is not an `UnexpectedStatusCodeError`
+ * - the body cannot be parsed as a JSON object with an `error` string
+ */
+export function extractTokenError(
+  tokenResponse: TokenRequestResponse | undefined,
+): string | undefined {
+  const err = tokenResponse?.error;
+  if (!(err instanceof UnexpectedStatusCodeError)) {
+    return undefined;
+  }
+  const parsed = oauthErrorBodySchema.safeParse(
+    (() => {
+      if (typeof err.reason === "object") {
+        return err.reason;
+      }
+      try {
+        return JSON.parse(err.reason ?? "");
+      } catch {
+        return undefined;
+      }
+    })(),
+  );
+  return parsed.success ? parsed.data.error : undefined;
 }

--- a/tests/helpers/refresh-token-validation-helpers.ts
+++ b/tests/helpers/refresh-token-validation-helpers.ts
@@ -1,16 +1,28 @@
 import { buildTamperedPopJwt } from "#/helpers/par-validation-helpers";
-import { createTokenDPoP, Jwk, JwtSignerJwk } from "@pagopa/io-wallet-oauth2";
+import {
+  createTokenDPoP,
+  fetchTokenResponse,
+  type FetchTokenResponseOptions,
+  Jwk,
+  JwtSignerJwk,
+} from "@pagopa/io-wallet-oauth2";
 import { UnexpectedStatusCodeError } from "@pagopa/io-wallet-utils";
 import { exportJWK, generateKeyPair } from "jose";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import type {
+  TokenRequestExecuteResponse,
   TokenRequestResponse,
   TokenRequestStepOptions,
 } from "@/step/issuance";
 
-import { partialCallbacks, signJwtCallback } from "@/logic";
+import {
+  createKeys,
+  fetchWithConfig,
+  partialCallbacks,
+  signJwtCallback,
+} from "@/logic";
 import { TokenRequestDefaultStep } from "@/step/issuance";
 import { KeyPairJwk } from "@/types";
 
@@ -80,6 +92,44 @@ export function withInvalidRefreshTokenDPoP(
       return super.run({
         ...options,
         dpopProof: invalidDpop,
+      });
+    }
+  } as typeof TokenRequestDefaultStep;
+}
+
+/**
+ * Wraps a token request step class to send the refresh-token token request
+ * without any DPoP proof header.
+ *
+ * Used for CI_102: the issuer MUST reject the token request because the
+ * DPoP proof is entirely absent (RFC 9449 §5.2).
+ */
+export function withMissingRefreshTokenDPoP(
+  StepClass: typeof TokenRequestDefaultStep,
+): typeof TokenRequestDefaultStep {
+  return class extends StepClass {
+    async run(options: TokenRequestStepOptions): Promise<TokenRequestResponse> {
+      return this.execute<TokenRequestExecuteResponse>(async () => {
+        // Generate a throwaway key pair so the return type is satisfied if the
+        // server unexpectedly accepts the request (which would be a compliance
+        // failure — the test asserts success: false).
+        const dPoPKey = await createKeys();
+
+        const fetchOptions = {
+          accessTokenEndpoint: options.accessTokenEndpoint,
+          accessTokenRequest: options.accessTokenRequest,
+          callbacks: { fetch: fetchWithConfig(this.config.network) },
+          clientAttestationDPoP: options.popAttestation,
+          walletAttestation: options.walletAttestation.attestation,
+        } satisfies Omit<FetchTokenResponseOptions, "dPoP">;
+
+        // dPoP intentionally omitted — tests that the issuer rejects requests
+        // without a DPoP proof (RFC 9449 §5.2).
+        const tokenResponse = await fetchTokenResponse(
+          fetchOptions as FetchTokenResponseOptions,
+        );
+
+        return { ...tokenResponse, dPoPKey };
       });
     }
   } as typeof TokenRequestDefaultStep;

--- a/tests/unit/orchestrator-reissuance.unit.spec.ts
+++ b/tests/unit/orchestrator-reissuance.unit.spec.ts
@@ -1,0 +1,417 @@
+/* eslint-disable max-lines-per-function */
+/**
+ * Unit tests for the Re-Issuance Flow in WalletIssuanceOrchestratorFlow.
+ *
+ * Verifies that:
+ * - reissuance() returns a typed unsuccessful result (without calling
+ *   PAR/authorize steps) when no refresh token is configured.
+ * - reissuance() runs the refresh-token path when a refresh token is configured.
+ * - issuance() is unchanged and never calls reissuance() internally.
+ * - reissuance() returns partial responses on token/nonce/credential failures.
+ */
+
+import { IssuerTestConfiguration } from "#/config/issuance-test-configuration";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { WalletIssuanceOrchestratorFlow } from "@/orchestrator/wallet-issuance-orchestrator-flow";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/logic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/logic")>();
+  return {
+    ...actual,
+    loadConfigWithHierarchy: vi.fn().mockReturnValue({
+      issuance: {
+        credential_offer_uri: "",
+        credential_types: ["dc_sd_jwt_PersonIdentificationData"],
+        save_credential: false,
+        url: "https://issuer.example.com",
+      },
+      logging: {
+        log_file: "",
+        log_file_format: "json",
+        log_format: "pretty",
+        log_level: "silent",
+      },
+      network: { max_retries: 1, timeout: 10, user_agent: "test" },
+      presentation: {
+        authorize_request_url:
+          "https://verifier.example.com/authorize?client_id=https://verifier.example.com",
+        verifier: "https://verifier.example.com",
+      },
+      steps_mapping: { mapping: {} },
+      trust: { trust_anchor_entity_configuration_url: "" },
+      trust_anchor: { port: 3000, ta_url: "http://localhost:3000" },
+      wallet: {
+        backup_storage_path: "./backup",
+        credentials_storage_path: "./credentials",
+        wallet_version: "1.0",
+      },
+    }),
+  };
+});
+
+vi.mock("@/functions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/functions")>();
+  return {
+    ...actual,
+    loadAttestation: vi.fn().mockResolvedValue({
+      attestation: "mock-attestation-jwt",
+      trustChain: [],
+      unitKey: {
+        privateKey: { crv: "P-256", d: "mock-d", kty: "EC" },
+        publicKey: {
+          crv: "P-256",
+          kid: "mock-kid",
+          kty: "EC",
+          x: "mock-x",
+          y: "mock-y",
+        },
+      },
+    }),
+    loadCredentialsForPresentation: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("@pagopa/io-wallet-oauth2", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@pagopa/io-wallet-oauth2")>();
+  return {
+    ...actual,
+    createClientAttestationPopJwt: vi
+      .fn()
+      .mockResolvedValue("mock-pop-attestation"),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStepFailure(message: string) {
+  return {
+    durationMs: 10,
+    error: new Error(message),
+    success: false as const,
+  };
+}
+
+function makeStepSuccess<T>(response: T) {
+  return { durationMs: 10, response, success: true as const };
+}
+
+const fetchMetadataSuccess = makeStepSuccess({
+  discoveredVia: "federation" as const,
+  entityStatementClaims: {
+    iss: "https://issuer.example.com",
+    metadata: {
+      oauth_authorization_server: {
+        authorization_endpoint: "https://issuer.example.com/authorize",
+        pushed_authorization_request_endpoint: "https://issuer.example.com/par",
+        token_endpoint: "https://issuer.example.com/token",
+      },
+      openid_credential_issuer: {
+        credential_configurations_supported: {
+          dc_sd_jwt_PersonIdentificationData: {},
+        },
+        credential_endpoint: "https://issuer.example.com/credential",
+        nonce_endpoint: "https://issuer.example.com/nonce",
+      },
+    },
+    sub: "https://issuer.example.com",
+  },
+  status: 200,
+});
+
+const tokenSuccess = makeStepSuccess({
+  access_token: "mock-access-token",
+  dPoPKey: {
+    privateKey: { crv: "P-256", d: "mock-d", kty: "EC" },
+    publicKey: {
+      crv: "P-256",
+      kid: "mock-kid",
+      kty: "EC",
+      x: "mock-x",
+      y: "mock-y",
+    },
+  },
+});
+
+const nonceSuccess = makeStepSuccess({ nonce: { c_nonce: "mock-c-nonce" } });
+
+const credentialSuccess = makeStepSuccess({
+  credentials: [{ credential: "mock-credential" }],
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WalletIssuanceOrchestratorFlow.reissuance()", () => {
+  let orchestrator: WalletIssuanceOrchestratorFlow;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new WalletIssuanceOrchestratorFlow(
+      IssuerTestConfiguration.createDefault(),
+    );
+  });
+
+  test("returns typed unsuccessful result when no refresh token is configured", async () => {
+    // No refresh_token in mock config — reissuance() must fail fast
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain(
+      "Re-Issuance Flow requires a refresh token",
+    );
+    // PAR, authorize, and token steps must not be called
+    const parSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.pushedAuthorizationRequestStep,
+      "run",
+    );
+    const authorizeSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.authorizeStep,
+      "run",
+    );
+    expect(parSpy).not.toHaveBeenCalled();
+    expect(authorizeSpy).not.toHaveBeenCalled();
+  });
+
+  test("runs refresh-token path when refresh_token is configured", async () => {
+    // Inject refresh_token into config
+    orchestrator.getConfig().issuance.refresh_token = "my-refresh-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.nonceRequestStep,
+      "run",
+    ).mockResolvedValue(nonceSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.credentialRequestStep,
+      "run",
+    ).mockResolvedValue(credentialSuccess as never);
+
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(true);
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toEqual(tokenSuccess);
+    expect(result.nonceResponse).toEqual(nonceSuccess);
+    expect(result.credentialResponse).toEqual(credentialSuccess);
+    // PAR and authorize must not have been called
+    expect(result).not.toHaveProperty("pushedAuthorizationRequestResponse");
+    expect(result).not.toHaveProperty("authorizeResponse");
+  });
+
+  test("token request receives grant_type=refresh_token and not PAR/authorize", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "test-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    const tokenRunSpy = vi
+      .spyOn(
+        // @ts-expect-error accessing private field for testing
+        orchestrator.tokenRequestStep,
+        "run",
+      )
+      .mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.nonceRequestStep,
+      "run",
+    ).mockResolvedValue(nonceSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.credentialRequestStep,
+      "run",
+    ).mockResolvedValue(credentialSuccess as never);
+
+    const parSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.pushedAuthorizationRequestStep,
+      "run",
+    );
+    const authorizeSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.authorizeStep,
+      "run",
+    );
+
+    await orchestrator.reissuance();
+
+    // PAR and authorize must NOT be called
+    expect(parSpy).not.toHaveBeenCalled();
+    expect(authorizeSpy).not.toHaveBeenCalled();
+
+    // Token step must be called with refresh_token grant
+    expect(tokenRunSpy).toHaveBeenCalledOnce();
+    const tokenCallArg = tokenRunSpy.mock.calls[0]?.[0];
+    expect(tokenCallArg?.accessTokenRequest).toMatchObject({
+      grant_type: "refresh_token",
+      refresh_token: "test-token",
+    });
+  });
+
+  test("issuance() still uses authorization-code flow when refresh_token is set", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "irrelevant-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    const parSpy = vi
+      .spyOn(
+        // @ts-expect-error accessing private field for testing
+        orchestrator.pushedAuthorizationRequestStep,
+        "run",
+      )
+      .mockResolvedValue(
+        makeStepSuccess({
+          codeVerifier: "mock-code-verifier",
+          request_uri: "urn:ietf:params:oauth:request_uri:mock",
+        }) as never,
+      );
+
+    const result = await orchestrator.issuance();
+
+    // issuance() should have attempted PAR (it may fail later, but PAR must be tried)
+    expect(parSpy).toHaveBeenCalledWith(expect.objectContaining({}));
+    // The result must not be the re-issuance response shape
+    expect(result).toHaveProperty("pushedAuthorizationRequestResponse");
+  });
+
+  test("token failure returns partial response with fetchMetadataResponse and tokenResponse", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "my-refresh-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(makeStepFailure("token endpoint returned 401"));
+
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("token endpoint returned 401");
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toBeDefined();
+    expect(result.nonceResponse).toBeUndefined();
+    expect(result.credentialResponse).toBeUndefined();
+  });
+
+  test("nonce failure returns partial response through tokenResponse", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "my-refresh-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.nonceRequestStep,
+      "run",
+    ).mockResolvedValue(makeStepFailure("nonce endpoint returned 500"));
+
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("nonce endpoint returned 500");
+    expect(result.tokenResponse).toEqual(tokenSuccess);
+    expect(result.nonceResponse).toBeDefined();
+    expect(result.credentialResponse).toBeUndefined();
+  });
+
+  test("credential failure returns partial response with all prior responses", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "my-refresh-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.nonceRequestStep,
+      "run",
+    ).mockResolvedValue(nonceSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.credentialRequestStep,
+      "run",
+    ).mockResolvedValue(makeStepFailure("credential endpoint returned 400"));
+
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("credential endpoint returned 400");
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toEqual(tokenSuccess);
+    expect(result.nonceResponse).toEqual(nonceSuccess);
+    expect(result.credentialResponse).toBeDefined();
+  });
+
+  test("never throws — error is always captured in result.error", async () => {
+    orchestrator.getConfig().issuance.refresh_token = "my-refresh-token";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockRejectedValue(new Error("unexpected network error"));
+
+    await expect(orchestrator.reissuance()).resolves.toMatchObject({
+      error: expect.objectContaining({ message: "unexpected network error" }),
+      success: false,
+    });
+  });
+});

--- a/tests/unit/orchestrator-reissuance.unit.spec.ts
+++ b/tests/unit/orchestrator-reissuance.unit.spec.ts
@@ -300,6 +300,36 @@ describe("WalletIssuanceOrchestratorFlow.reissuance()", () => {
         }) as never,
       );
 
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.authorizeStep,
+      "run",
+    ).mockResolvedValue(
+      makeStepSuccess({
+        authorizeResponse: { code: "mock-auth-code" },
+        iss: "https://issuer.example.com",
+        requestObjectJwt: "mock-request-object-jwt",
+      }) as never,
+    );
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.nonceRequestStep,
+      "run",
+    ).mockResolvedValue(nonceSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.credentialRequestStep,
+      "run",
+    ).mockResolvedValue(credentialSuccess as never);
+
     const result = await orchestrator.issuance();
 
     // issuance() should have attempted PAR (it may fail later, but PAR must be tried)

--- a/tests/unit/orchestrator-reissuance.unit.spec.ts
+++ b/tests/unit/orchestrator-reissuance.unit.spec.ts
@@ -161,14 +161,7 @@ describe("WalletIssuanceOrchestratorFlow.reissuance()", () => {
   });
 
   test("returns typed unsuccessful result when no refresh token is configured", async () => {
-    // No refresh_token in mock config — reissuance() must fail fast
-    const result = await orchestrator.reissuance();
-
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain(
-      "Re-Issuance Flow requires a refresh token",
-    );
-    // PAR, authorize, and token steps must not be called
+    // PAR, authorize, and token steps must not be called — spy before running
     const parSpy = vi.spyOn(
       // @ts-expect-error accessing private field for testing
       orchestrator.pushedAuthorizationRequestStep,
@@ -178,6 +171,14 @@ describe("WalletIssuanceOrchestratorFlow.reissuance()", () => {
       // @ts-expect-error accessing private field for testing
       orchestrator.authorizeStep,
       "run",
+    );
+
+    // No refresh_token in mock config — reissuance() must fail fast
+    const result = await orchestrator.reissuance();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain(
+      "Re-Issuance Flow requires a refresh token",
     );
     expect(parSpy).not.toHaveBeenCalled();
     expect(authorizeSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
#### Motivation and Context

Adding Re-Issuance Flow with support to DPoP-bound Refresh Tokens improves the conformance test about token management process. This change is necessary to ensure that refresh tokens are validated correctly and to provide robust error handling. 

#### How Has This Been Tested?

The changes have been thoroughly tested through the addition of unit tests covering various scenarios, including:
- Validating DPoP proof and handling invalid tokens.
- Ensuring proper error messages for missing or expired tokens.
- Testing TLS protection on the refresh-token endpoint.
- Verifying the behavior of the re-issuance flow under different conditions.

