### PR TITLE
Add support for Deferred Issuance Flow

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -53,12 +53,12 @@ credential_types[] = dc_sd_jwt_EuropeanDisabilityCard
 # refresh_token = <your-refresh-token>
 
 # Optional: run the Deferred Issuance Flow (call orchestrator.deferred()).
-# Both refresh_token_deferred and transaction_id are required together.
+# Both refresh_token_deferred and transaction_id_deferred are required together.
 # refresh_token_deferred is the DPoP-bound Refresh Token used to obtain a new
-# access token for the Deferred Endpoint. transaction_id is the value returned
+# access token for the Deferred Endpoint. transaction_id_deferred is the value returned
 # by the issuer in the original pending credential response.
 # refresh_token_deferred = <your-deferred-refresh-token>
-# transaction_id = <your-transaction-id>
+# transaction_id_deferred = <your-transaction-id>
 
 [presentation]
 # Optional: override the directory where presentation test specs are discovered

--- a/config.example.ini
+++ b/config.example.ini
@@ -52,6 +52,14 @@ credential_types[] = dc_sd_jwt_EuropeanDisabilityCard
 # of the full authorization-code flow. When set, call orchestrator.reissuance().
 # refresh_token = <your-refresh-token>
 
+# Optional: run the Deferred Issuance Flow (call orchestrator.deferred()).
+# Both refresh_token_deferred and transaction_id are required together.
+# refresh_token_deferred is the DPoP-bound Refresh Token used to obtain a new
+# access token for the Deferred Endpoint. transaction_id is the value returned
+# by the issuer in the original pending credential response.
+# refresh_token_deferred = <your-deferred-refresh-token>
+# transaction_id = <your-transaction-id>
+
 [presentation]
 # Optional: override the directory where presentation test specs are discovered
 # tests_dir = ./tests/conformance/presentation

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,16 @@ import { packageRoot, readPackageVersion } from "@/logic/runtime-paths";
 const nodeRequire = createRequire(import.meta.url);
 const experimentalWarningFlag = "--disable-warning=ExperimentalWarning";
 
+function applyEnvOption(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  value: boolean | number | string | undefined,
+): void {
+  if (value !== undefined) {
+    env[key] = String(value);
+  }
+}
+
 function ensureExperimentalWarningsDisabled(): void {
   if (
     process.env.NODE_OPTIONS?.split(/\s+/).includes(experimentalWarningFlag)
@@ -87,61 +97,51 @@ function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   if (options.fileIni) {
     env.CONFIG_FILE_INI = resolve(process.cwd(), options.fileIni);
   }
-  if (options.credentialIssuerUri) {
-    env.CONFIG_CREDENTIAL_ISSUER_URI = options.credentialIssuerUri;
-  }
-  if (options.credentialOfferUri) {
-    env.CONFIG_CREDENTIAL_OFFER_URI = options.credentialOfferUri;
-  }
-  if (options.presentationAuthorizeUri) {
-    env.CONFIG_PRESENTATION_AUTHORIZE_URI = options.presentationAuthorizeUri;
-  }
-  if (options.credentialTypes) {
-    env.CONFIG_CREDENTIAL_TYPES = options.credentialTypes;
-  }
-  if (options.timeout !== undefined) {
-    env.CONFIG_TIMEOUT = options.timeout.toString();
-  }
-  if (options.maxRetries !== undefined) {
-    env.CONFIG_MAX_RETRIES = options.maxRetries.toString();
-  }
-  if (options.logLevel) {
-    env.CONFIG_LOG_LEVEL = options.logLevel;
-  }
-  if (options.logFile) {
-    env.CONFIG_LOG_FILE = options.logFile;
-  }
-  if (options.port !== undefined) {
-    env.CONFIG_PORT = options.port.toString();
-  }
-  if (options.saveCredential !== undefined) {
-    env.CONFIG_SAVE_CREDENTIAL = options.saveCredential.toString();
-  }
-  if (options.issuanceTestsDir) {
-    env.CONFIG_ISSUANCE_TESTS_DIR = options.issuanceTestsDir;
-  }
-  if (options.issuanceCertificateSubject) {
-    env.CONFIG_ISSUANCE_CERTIFICATE_SUBJECT =
-      options.issuanceCertificateSubject;
-  }
-  if (options.presentationTestsDir) {
-    env.CONFIG_PRESENTATION_TESTS_DIR = options.presentationTestsDir;
-  }
-  if (options.stepsMapping) {
-    env.CONFIG_STEPS_MAPPING = options.stepsMapping;
-  }
-  if (options.unsafeTls) {
-    env.CONFIG_UNSAFE_TLS = "true";
-  }
-  if (options.tests) {
-    env.TESTS = options.tests;
-  }
-  if (options.walletVersion) {
-    env.CONFIG_WALLET_VERSION = options.walletVersion;
-  }
-  if (options.refreshToken) {
-    env.CONFIG_REFRESH_TOKEN = options.refreshToken;
-  }
+
+  applyEnvOption(
+    env,
+    "CONFIG_CREDENTIAL_ISSUER_URI",
+    options.credentialIssuerUri,
+  );
+  applyEnvOption(
+    env,
+    "CONFIG_CREDENTIAL_OFFER_URI",
+    options.credentialOfferUri,
+  );
+  applyEnvOption(
+    env,
+    "CONFIG_PRESENTATION_AUTHORIZE_URI",
+    options.presentationAuthorizeUri,
+  );
+  applyEnvOption(env, "CONFIG_CREDENTIAL_TYPES", options.credentialTypes);
+  applyEnvOption(env, "CONFIG_TIMEOUT", options.timeout);
+  applyEnvOption(env, "CONFIG_MAX_RETRIES", options.maxRetries);
+  applyEnvOption(env, "CONFIG_LOG_LEVEL", options.logLevel);
+  applyEnvOption(env, "CONFIG_LOG_FILE", options.logFile);
+  applyEnvOption(env, "CONFIG_PORT", options.port);
+  applyEnvOption(env, "CONFIG_SAVE_CREDENTIAL", options.saveCredential);
+  applyEnvOption(env, "CONFIG_ISSUANCE_TESTS_DIR", options.issuanceTestsDir);
+  applyEnvOption(
+    env,
+    "CONFIG_ISSUANCE_CERTIFICATE_SUBJECT",
+    options.issuanceCertificateSubject,
+  );
+  applyEnvOption(
+    env,
+    "CONFIG_PRESENTATION_TESTS_DIR",
+    options.presentationTestsDir,
+  );
+  applyEnvOption(env, "CONFIG_STEPS_MAPPING", options.stepsMapping);
+  applyEnvOption(env, "CONFIG_UNSAFE_TLS", options.unsafeTls);
+  applyEnvOption(env, "TESTS", options.tests);
+  applyEnvOption(env, "CONFIG_WALLET_VERSION", options.walletVersion);
+  applyEnvOption(env, "CONFIG_REFRESH_TOKEN", options.refreshToken);
+  applyEnvOption(
+    env,
+    "CONFIG_REFRESH_TOKEN_DEFERRED",
+    options.refreshTokenDeferred,
+  );
+  applyEnvOption(env, "CONFIG_TRANSACTION_ID", options.transactionId);
 
   return env;
 }
@@ -231,6 +231,14 @@ function addCommonOptions(command: Command): Command {
     .option(
       "--refresh-token <token>",
       "Use a DPoP-bound Refresh Token to run the Re-Issuance Flow (env: CONFIG_REFRESH_TOKEN)",
+    )
+    .option(
+      "--refresh-token-deferred <token>",
+      "DPoP-bound Refresh Token used to obtain a new access token for the Deferred Issuance Flow (env: CONFIG_REFRESH_TOKEN_DEFERRED)",
+    )
+    .option(
+      "--transaction-id <id>",
+      "Transaction ID returned in the pending credential response, required for the Deferred Issuance Flow (env: CONFIG_TRANSACTION_ID)",
     );
 }
 

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -38,10 +38,12 @@ export interface CliOptions {
   presentationAuthorizeUri?: string;
   presentationTestsDir?: string;
   refreshToken?: string;
+  refreshTokenDeferred?: string;
   saveCredential?: boolean;
   stepsMapping?: string;
   tests?: string;
   timeout?: number;
+  transactionId?: string;
   trustAnchorCertDir?: string;
   unsafeTls?: boolean;
   walletVersion?: string;
@@ -350,6 +352,10 @@ const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
       .filter((t) => t.length > 0),
   }),
   ...(options.refreshToken && { refresh_token: options.refreshToken }),
+  ...(options.refreshTokenDeferred && {
+    refresh_token_deferred: options.refreshTokenDeferred,
+  }),
+  ...(options.transactionId && { transaction_id: options.transactionId }),
   ...(options.saveCredential !== undefined && {
     save_credential: options.saveCredential,
   }),
@@ -520,6 +526,12 @@ function readCliOptionsFromEnv(): CliOptions {
     "CONFIG_PRESENTATION_TESTS_DIR",
   );
   readStringEnv(options, "refreshToken", "CONFIG_REFRESH_TOKEN");
+  readStringEnv(
+    options,
+    "refreshTokenDeferred",
+    "CONFIG_REFRESH_TOKEN_DEFERRED",
+  );
+  readStringEnv(options, "transactionId", "CONFIG_TRANSACTION_ID");
   readStringEnv(options, "stepsMapping", "CONFIG_STEPS_MAPPING");
   readBooleanEnv(options, "unsafeTls", "CONFIG_UNSAFE_TLS");
   readStringEnv(options, "trustAnchorCertDir", "CONFIG_TRUST_ANCHOR_CERT_DIR");

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -355,7 +355,7 @@ const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
   ...(options.refreshTokenDeferred && {
     refresh_token_deferred: options.refreshTokenDeferred,
   }),
-  ...(options.transactionId && { transaction_id: options.transactionId }),
+  ...(options.transactionId && { transaction_id_deferred: options.transactionId }),
   ...(options.saveCredential !== undefined && {
     save_credential: options.saveCredential,
   }),

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -355,7 +355,9 @@ const buildIssuanceConfig: ConfigSectionBuilder<Config["issuance"]> = (
   ...(options.refreshTokenDeferred && {
     refresh_token_deferred: options.refreshTokenDeferred,
   }),
-  ...(options.transactionId && { transaction_id_deferred: options.transactionId }),
+  ...(options.transactionId && {
+    transaction_id_deferred: options.transactionId,
+  }),
   ...(options.saveCredential !== undefined && {
     save_credential: options.saveCredential,
   }),

--- a/src/orchestrator/errors.ts
+++ b/src/orchestrator/errors.ts
@@ -34,6 +34,18 @@ export class CredentialConfigurationError extends OrchestratorError {
   }
 }
 
+export class DeferredIssuancePreconditionError extends OrchestratorError {
+  constructor() {
+    super(
+      "Deferred Issuance Flow requires both a deferred refresh token and a transaction id. " +
+        "Set 'refresh_token_deferred' and 'transaction_id' under [issuance] in config.ini or " +
+        "pass --refresh-token-deferred <token> --transaction-id <id>.",
+      "DEFERRED_ISSUANCE_PRECONDITION_FAILED",
+    );
+    this.name = "DeferredIssuancePreconditionError";
+  }
+}
+
 export class IssuerMetadataError extends OrchestratorError {
   readonly missingField: string;
   readonly parentObject: string;

--- a/src/orchestrator/errors.ts
+++ b/src/orchestrator/errors.ts
@@ -38,7 +38,7 @@ export class DeferredIssuancePreconditionError extends OrchestratorError {
   constructor() {
     super(
       "Deferred Issuance Flow requires both a deferred refresh token and a transaction id. " +
-        "Set 'refresh_token_deferred' and 'transaction_id' under [issuance] in config.ini or " +
+        "Set 'refresh_token_deferred' and 'transaction_id_deferred' under [issuance] in config.ini or " +
         "pass --refresh-token-deferred <token> --transaction-id <id>.",
       "DEFERRED_ISSUANCE_PRECONDITION_FAILED",
     );

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -148,7 +148,7 @@ export class WalletIssuanceOrchestratorFlow {
 
     try {
       const refreshTokenDeferred = this.config.issuance.refresh_token_deferred;
-      const transactionId = this.config.issuance.transaction_id;
+      const transactionId = this.config.issuance.transaction_id_deferred;
 
       if (!refreshTokenDeferred || !transactionId) {
         throw new DeferredIssuancePreconditionError();

--- a/src/orchestrator/wallet-issuance-orchestrator-flow.ts
+++ b/src/orchestrator/wallet-issuance-orchestrator-flow.ts
@@ -18,6 +18,7 @@ import {
 import { REDIRECT_URI } from "@/logic/constants";
 import {
   CredentialConfigurationError,
+  DeferredIssuancePreconditionError,
   IssuerMetadataError,
   OrchestratorError,
   ReissuancePreconditionError,
@@ -28,6 +29,8 @@ import {
   AuthorizeStepResponse,
   CredentialRequestDefaultStep,
   CredentialRequestResponse,
+  DeferredCredentialRequestDefaultStep,
+  DeferredCredentialRequestResponse,
   FetchMetadataDefaultStep,
   FetchMetadataStepResponse,
   NonceRequestDefaultStep,
@@ -41,6 +44,7 @@ import { assertStepSuccess } from "@/step/step-flow";
 import {
   AttestationResponse,
   Config,
+  DeferredIssuanceFlowResponse,
   IssuanceFlowResponse,
   KeyPair,
   ReissuanceFlowResponse,
@@ -53,6 +57,7 @@ import {
 export class WalletIssuanceOrchestratorFlow {
   private _authorizeResponse?: AuthorizeStepResponse;
   private _credentialResponse?: CredentialRequestResponse;
+  private _deferredCredentialResponse?: DeferredCredentialRequestResponse;
   private _fetchMetadataResponse?: FetchMetadataStepResponse;
   private _nonceResponse?: NonceRequestResponse;
   private _pushedAuthorizationRequestResponse?: PushedAuthorizationRequestResponse;
@@ -64,6 +69,7 @@ export class WalletIssuanceOrchestratorFlow {
   private authorizeStep: AuthorizeDefaultStep;
   private config: Config;
   private credentialRequestStep: CredentialRequestDefaultStep;
+  private deferredCredentialRequestStep: DeferredCredentialRequestDefaultStep;
   private fetchMetadataStep: FetchMetadataDefaultStep;
   private issuanceConfig: IssuerTestConfiguration;
   private log = createLogger();
@@ -119,6 +125,72 @@ export class WalletIssuanceOrchestratorFlow {
       this.config,
       this.log,
     );
+
+    this.deferredCredentialRequestStep =
+      new DeferredCredentialRequestDefaultStep(this.config, this.log);
+  }
+
+  /**
+   * Executes the Deferred Issuance Flow.
+   *
+   * Requires both `refresh_token_deferred` and `transaction_id` to be set in
+   * the issuance configuration (or passed via CLI / env). Fails fast without
+   * contacting any remote endpoint when either prerequisite is missing.
+   *
+   * The flow:
+   *   1. Fetch issuer metadata.
+   *   2. Load wallet attestation.
+   *   3. Request a new access token using the deferred refresh token.
+   *   4. POST to `deferred_credential_endpoint` with the `transaction_id`.
+   */
+  async deferred(): Promise<DeferredIssuanceFlowResponse> {
+    this.resetResponses();
+
+    try {
+      const refreshTokenDeferred = this.config.issuance.refresh_token_deferred;
+      const transactionId = this.config.issuance.transaction_id;
+
+      if (!refreshTokenDeferred || !transactionId) {
+        throw new DeferredIssuancePreconditionError();
+      }
+
+      const {
+        dPoPKey,
+        fetchMetadataResponse,
+        tokenResponse,
+        walletAttestationResponse,
+      } = await this.runThroughRefreshToken(refreshTokenDeferred);
+
+      const accessToken = tokenResponse.response?.access_token;
+      if (!accessToken)
+        throw new StepOutputError(TokenRequestDefaultStep.tag, "access_token");
+
+      const deferredCredentialResponse =
+        await this.requestDeferredCredentialWithToken({
+          accessToken,
+          dPoPKey,
+          fetchMetadataResponse,
+          transactionId,
+        });
+
+      return {
+        deferredCredentialResponse,
+        fetchMetadataResponse,
+        success: true,
+        tokenResponse,
+        walletAttestationResponse,
+      };
+    } catch (e) {
+      this.log.error("Error in Deferred Issuance Flow!", e);
+      return {
+        deferredCredentialResponse: this._deferredCredentialResponse,
+        error: e instanceof Error ? e : new Error(String(e)),
+        fetchMetadataResponse: this._fetchMetadataResponse,
+        success: false,
+        tokenResponse: this._tokenResponse,
+        walletAttestationResponse: this._walletAttestationResponse,
+      };
+    }
   }
 
   async findCredentialConfig(): Promise<{
@@ -684,9 +756,64 @@ export class WalletIssuanceOrchestratorFlow {
     return { credentialResponse, nonceResponse };
   }
 
+  /**
+   * Sends a Deferred Credential Request to the deferred_credential_endpoint using
+   * the access token and transaction_id. Saves the credential to disk if configured.
+   */
+  private async requestDeferredCredentialWithToken({
+    accessToken,
+    dPoPKey,
+    fetchMetadataResponse,
+    transactionId,
+  }: {
+    accessToken: string;
+    dPoPKey: KeyPair;
+    fetchMetadataResponse: FetchMetadataStepResponse;
+    transactionId: string;
+  }): Promise<DeferredCredentialRequestResponse> {
+    const entityStatementClaims =
+      fetchMetadataResponse.response?.entityStatementClaims;
+
+    const deferredCredentialEndpoint =
+      entityStatementClaims?.metadata?.openid_credential_issuer
+        ?.deferred_credential_endpoint;
+    if (!deferredCredentialEndpoint) {
+      throw new IssuerMetadataError(
+        "deferred_credential_endpoint",
+        "openid_credential_issuer",
+        "Deferred Credential Request",
+      );
+    }
+
+    const deferredCredentialResponse =
+      await this.deferredCredentialRequestStep.run({
+        accessToken,
+        deferredCredentialEndpoint,
+        dPoPKey,
+        transactionId,
+      });
+    this._deferredCredentialResponse = deferredCredentialResponse;
+    this.log.flowStep(
+      5,
+      this.TOTAL_STEPS,
+      "Deferred Credential Request",
+      deferredCredentialResponse.success,
+      deferredCredentialResponse.durationMs ?? 0,
+    );
+    assertStepSuccess(
+      deferredCredentialResponse,
+      "Deferred Credential Request",
+    );
+
+    this.saveFirstCredentialIfConfigured(deferredCredentialResponse);
+
+    return deferredCredentialResponse;
+  }
+
   private resetResponses(): void {
     this._authorizeResponse = undefined;
     this._credentialResponse = undefined;
+    this._deferredCredentialResponse = undefined;
     this._fetchMetadataResponse = undefined;
     this._nonceResponse = undefined;
     this._pushedAuthorizationRequestResponse = undefined;
@@ -799,5 +926,35 @@ export class WalletIssuanceOrchestratorFlow {
       tokenResponse,
       walletAttestationResponse,
     };
+  }
+
+  private saveFirstCredentialIfConfigured(
+    deferredCredentialResponse: DeferredCredentialRequestResponse,
+  ): void {
+    if (!this.config.issuance.save_credential) return;
+
+    const firstCredential =
+      deferredCredentialResponse.response &&
+      "credentials" in deferredCredentialResponse.response
+        ? (
+            deferredCredentialResponse.response as {
+              credentials: { credential?: string }[];
+            }
+          ).credentials?.[0]
+        : undefined;
+
+    if (!firstCredential?.credential) return;
+
+    const savedPath = saveCredentialToDisk(
+      this.config.wallet.credentials_storage_path,
+      this.issuanceConfig.credentialConfigurationId,
+      firstCredential.credential,
+      this.config.wallet.wallet_version,
+    );
+    if (savedPath) {
+      this.log.info(`Deferred credential saved to disk: ${savedPath}`);
+    } else {
+      this.log.error("Failed to save deferred credential to disk");
+    }
   }
 }

--- a/src/step/issuance/deferred-credential-request-step.ts
+++ b/src/step/issuance/deferred-credential-request-step.ts
@@ -1,0 +1,141 @@
+import {
+  createTokenDPoP,
+  CreateTokenDPoPOptions,
+} from "@pagopa/io-wallet-oauth2";
+import {
+  CredentialResponse,
+  zCredentialResponseV1_0,
+  zCredentialResponseV1_3,
+} from "@pagopa/io-wallet-oid4vci";
+import { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
+
+import { fetchWithConfig, partialCallbacks, signJwtCallback } from "@/logic";
+import { KeyPair } from "@/types/key-pair";
+
+import { StepFlow, StepResponse } from "../step-flow";
+
+export type DeferredCredentialRequestResponse = StepResponse & {
+  response?: CredentialResponse;
+};
+
+export interface DeferredCredentialRequestStepOptions {
+  /**
+   * DPoP-bound access token obtained from the token endpoint.
+   */
+  accessToken: string;
+
+  /**
+   * Deferred Credential Endpoint URL from the issuer metadata.
+   */
+  deferredCredentialEndpoint: string;
+
+  /**
+   * The same ephemeral DPoP key pair that was used to bind the access token.
+   * MUST be reused here to produce a valid DPoP proof for the deferred request.
+   */
+  dPoPKey: KeyPair;
+
+  /**
+   * Transaction ID returned in the original (pending) credential response.
+   */
+  transactionId: string;
+}
+
+/**
+ * Flow step to request a previously-pending credential from the issuer's
+ * Deferred Credential Endpoint using a transaction_id and a valid access token.
+ *
+ * The step mirrors the credential-request pattern: it builds a DPoP proof with
+ * the same ephemeral key pair used in the token request, then POSTs to the
+ * deferred endpoint with the access token and the transaction_id in the body.
+ */
+export class DeferredCredentialRequestDefaultStep extends StepFlow {
+  static readonly tag = "DEFERRED_CREDENTIAL_REQUEST";
+
+  async run(
+    options: DeferredCredentialRequestStepOptions,
+  ): Promise<DeferredCredentialRequestResponse> {
+    const log = this.log;
+
+    log.debug("Starting Deferred Credential Request Step");
+
+    return this.execute<CredentialResponse>(async () => {
+      log.info("Generating DPoP for Deferred Credential Request...");
+      const dpop = await this.buildDPoP(options);
+      log.debug("DPoP JWT:", dpop);
+
+      log.info(
+        `Sending Deferred Credential Request to ${options.deferredCredentialEndpoint}`,
+      );
+      const response = await this.fetchDeferred(options, dpop);
+      log.debug(
+        "Deferred Credential Response:",
+        JSON.stringify(response, null, 2),
+      );
+
+      return response;
+    });
+  }
+
+  tag(): string {
+    return DeferredCredentialRequestDefaultStep.tag;
+  }
+
+  private async buildDPoP(
+    options: DeferredCredentialRequestStepOptions,
+  ): Promise<string> {
+    const { dPoPKey } = options;
+
+    const dpopOptions: CreateTokenDPoPOptions = {
+      accessToken: options.accessToken,
+      callbacks: {
+        ...partialCallbacks,
+        signJwt: signJwtCallback([dPoPKey.privateKey]),
+      },
+      signer: {
+        alg: "ES256",
+        method: "jwk",
+        publicJwk: dPoPKey.publicKey,
+      },
+      tokenRequest: {
+        method: "POST",
+        url: options.deferredCredentialEndpoint,
+      },
+    };
+
+    const { jwt } = await createTokenDPoP(dpopOptions);
+
+    return jwt;
+  }
+
+  private async fetchDeferred(
+    options: DeferredCredentialRequestStepOptions,
+    dpop: string,
+  ): Promise<CredentialResponse> {
+    const customFetch = fetchWithConfig(this.config.network);
+
+    const httpResponse = await customFetch(options.deferredCredentialEndpoint, {
+      body: JSON.stringify({ transaction_id: options.transactionId }),
+      headers: {
+        Authorization: `DPoP ${options.accessToken}`,
+        "Content-Type": "application/json",
+        DPoP: dpop,
+      },
+      method: "POST",
+    });
+
+    if (!httpResponse.ok && httpResponse.status !== 202) {
+      throw new Error(
+        `Deferred Credential Request failed with status ${httpResponse.status}`,
+      );
+    }
+
+    const body: unknown = await httpResponse.json();
+
+    const schema = this.ioWalletSdkConfig.isVersion(ItWalletSpecsVersion.V1_3)
+      ? zCredentialResponseV1_3
+      : zCredentialResponseV1_0;
+
+    return schema.parse(body);
+  }
+}

--- a/src/step/issuance/index.ts
+++ b/src/step/issuance/index.ts
@@ -1,5 +1,6 @@
 export * from "./authorize-step";
 export * from "./credential-request-step";
+export * from "./deferred-credential-request-step";
 export * from "./fetch-metadata-step";
 export * from "./nonce-request-step";
 export * from "./pushed-authorization-request-step";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,7 +29,7 @@ export const configSchema = z.object({
     refresh_token_deferred: z.string().optional(),
     save_credential: zBooleanFromString.optional().default(false),
     tests_dir: z.string().default("./tests/issuance"),
-    transaction_id: z.string().optional(),
+    transaction_id_deferred: z.string().optional(),
     url: z.string().url(),
   }),
   issuer: z.object({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -26,8 +26,10 @@ export const configSchema = z.object({
       .optional(),
     credential_types: z.array(z.string()).optional().default([]),
     refresh_token: z.string().optional(),
+    refresh_token_deferred: z.string().optional(),
     save_credential: zBooleanFromString.optional().default(false),
     tests_dir: z.string().default("./tests/issuance"),
+    transaction_id: z.string().optional(),
     url: z.string().url(),
   }),
   issuer: z.object({

--- a/src/types/issuance-orchestrator-context.ts
+++ b/src/types/issuance-orchestrator-context.ts
@@ -1,6 +1,7 @@
 import {
   AuthorizeStepResponse,
   CredentialRequestResponse,
+  DeferredCredentialRequestResponse,
   FetchMetadataStepResponse,
   NonceRequestResponse,
   PushedAuthorizationRequestResponse,
@@ -9,6 +10,15 @@ import {
 
 import { AttestationResponse } from "./attestation-response";
 import { KeyPair } from "./key-pair";
+
+export interface DeferredIssuanceFlowResponse {
+  deferredCredentialResponse?: DeferredCredentialRequestResponse;
+  error?: Error;
+  fetchMetadataResponse?: FetchMetadataStepResponse;
+  success: boolean;
+  tokenResponse?: TokenRequestResponse;
+  walletAttestationResponse?: AttestationResponse;
+}
 
 export interface IssuanceFlowResponse {
   authorizeResponse?: AuthorizeStepResponse;

--- a/tests/conformance/issuance/deferred-endpoint.issuance.spec.ts
+++ b/tests/conformance/issuance/deferred-endpoint.issuance.spec.ts
@@ -9,7 +9,10 @@ import {
 } from "@pagopa/io-wallet-utils";
 import { beforeAll, describe, expect, test } from "vitest";
 
-import type { DeferredCredentialRequestResponse } from "@/step/issuance";
+import type {
+  DeferredCredentialRequestResponse,
+  FetchMetadataStepResponse,
+} from "@/step/issuance";
 
 import { loadConfigWithHierarchy } from "@/logic";
 import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
@@ -28,12 +31,14 @@ testConfigs.forEach((testConfig) => {
       const baseLog = orchestrator.getLog();
 
       let deferredCredentialResponse: DeferredCredentialRequestResponse;
+      let fetchMetadataResponse: FetchMetadataStepResponse;
 
       beforeAll(async () => {
         try {
           const result = await orchestrator.deferred();
           assertDeferredIssuanceFlowSuccess(result);
 
+          fetchMetadataResponse = result.fetchMetadataResponse;
           deferredCredentialResponse = result.deferredCredentialResponse;
 
           baseLog.info("Deferred issuance flow completed successfully");
@@ -47,6 +52,44 @@ testConfigs.forEach((testConfig) => {
       });
 
       useTestSummary(baseLog, testConfig.name);
+
+      test("CI_081: Deferred Endpoint Issuance | Credential Issuer supports the Deferred Flow", async () => {
+        const log = baseLog.withTag("CI_081");
+        const DESCRIPTION =
+          "Issuer supports the Deferred Flow and returns a valid deferred refresh token and transaction_id";
+
+        let testSuccess = false;
+        try {
+          expect(
+            fetchMetadataResponse.success,
+            "Fetch metadata step failed",
+          ).toBe(true);
+          expect(
+            fetchMetadataResponse.response,
+            "Fetch metadata response body is undefined",
+          ).toBeDefined();
+
+          const entityStatementClaims =
+            fetchMetadataResponse.response?.entityStatementClaims;
+          const deferredCredentialEndpoint =
+            entityStatementClaims?.metadata?.openid_credential_issuer
+              ?.deferred_credential_endpoint;
+
+          expect(
+            deferredCredentialEndpoint,
+            "Issuer metadata does not contain deferred_credential_endpoint",
+          ).toBeDefined();
+
+          log.debug(
+            "→ Deferred credential endpoint is ",
+            deferredCredentialEndpoint,
+          );
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      });
 
       test("CI_088a: Deferred Endpoint Issuance | Access Token allows access to Deferred endpoint for obtaining new Digital Credentials after interval or readiness notification", async () => {
         const log = baseLog.withTag("CI_088a");

--- a/tests/conformance/issuance/deferred-endpoint.issuance.spec.ts
+++ b/tests/conformance/issuance/deferred-endpoint.issuance.spec.ts
@@ -1,0 +1,93 @@
+import type { ImmediateCredentialResponse } from "@pagopa/io-wallet-oid4vci";
+
+import { defineIssuanceTest } from "#/config/test-metadata";
+import { assertDeferredIssuanceFlowSuccess } from "#/helpers/flow-assertion-helpers";
+import { useTestSummary } from "#/helpers/use-test-summary";
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import type { DeferredCredentialRequestResponse } from "@/step/issuance";
+
+import { loadConfigWithHierarchy } from "@/logic";
+import { WalletIssuanceOrchestratorFlow } from "@/orchestrator";
+
+const testConfigs = await defineIssuanceTest("DeferredEndpointIssuance");
+
+const isV1_0 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: loadConfigWithHierarchy().wallet.wallet_version,
+}).isVersion(ItWalletSpecsVersion.V1_0);
+
+testConfigs.forEach((testConfig) => {
+  describe.skipIf(isV1_0)(
+    `[${testConfig.name}] Deferred Endpoint Issuance`,
+    () => {
+      const orchestrator = new WalletIssuanceOrchestratorFlow(testConfig);
+      const baseLog = orchestrator.getLog();
+
+      let deferredCredentialResponse: DeferredCredentialRequestResponse;
+
+      beforeAll(async () => {
+        try {
+          const result = await orchestrator.deferred();
+          assertDeferredIssuanceFlowSuccess(result);
+
+          deferredCredentialResponse = result.deferredCredentialResponse;
+
+          baseLog.info("Deferred issuance flow completed successfully");
+        } catch (e) {
+          baseLog.error(e);
+          throw e;
+        } finally {
+          // Give time for all logs to be flushed before starting tests
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      });
+
+      useTestSummary(baseLog, testConfig.name);
+
+      test("CI_088a: Deferred Endpoint Issuance | Access Token allows access to Deferred endpoint for obtaining new Digital Credentials after interval or readiness notification", async () => {
+        const log = baseLog.withTag("CI_088a");
+        const DESCRIPTION =
+          "Access token successfully used for Deferred endpoint and credential obtained";
+
+        let testSuccess = false;
+        try {
+          expect(
+            deferredCredentialResponse.success,
+            "Deferred credential request step failed",
+          ).toBe(true);
+          expect(
+            deferredCredentialResponse.response,
+            "Deferred credential response body is undefined",
+          ).toBeDefined();
+
+          const response = deferredCredentialResponse.response;
+
+          expect(
+            response && "credentials" in response,
+            "Deferred credential response does not contain credentials (issuer may have returned a pending transaction_id instead of a credential)",
+          ).toBe(true);
+
+          // Safe cast: we have verified 'credentials' is present via the expect above
+          const immediateResponse = response as ImmediateCredentialResponse;
+
+          expect(
+            immediateResponse.credentials.length,
+            "Deferred credential response contains no credentials",
+          ).toBeGreaterThan(0);
+          expect(
+            immediateResponse.credentials[0]?.credential,
+            "First deferred credential value is undefined",
+          ).toBeDefined();
+
+          testSuccess = true;
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      });
+    },
+  );
+});

--- a/tests/helpers/flow-assertion-helpers.ts
+++ b/tests/helpers/flow-assertion-helpers.ts
@@ -1,5 +1,25 @@
-import type { IssuanceFlowResponse, ReissuanceFlowResponse } from "@/types";
+import type {
+  DeferredIssuanceFlowResponse,
+  IssuanceFlowResponse,
+  ReissuanceFlowResponse,
+} from "@/types";
 import type { PresentationFlowResponse } from "@/types";
+
+/**
+ * Asserts that a deferred issuance flow completed successfully.
+ * Narrows the type so all step responses are non-optional.
+ */
+export function assertDeferredIssuanceFlowSuccess(
+  result: DeferredIssuanceFlowResponse,
+): asserts result is Required<Omit<DeferredIssuanceFlowResponse, "error">> & {
+  success: true;
+} {
+  if (!result.success) {
+    throw new Error(
+      `Deferred issuance flow failed: ${result.error?.message ?? "unknown error"}`,
+    );
+  }
+}
 
 /**
  * Asserts that an issuance flow completed successfully.

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -18,9 +18,11 @@ const envKeys = [
   "CONFIG_MAX_RETRIES",
   "CONFIG_PRESENTATION_TESTS_DIR",
   "CONFIG_PORT",
+  "CONFIG_REFRESH_TOKEN_DEFERRED",
   "CONFIG_SAVE_CREDENTIAL",
   "CONFIG_STEPS_MAPPING",
   "CONFIG_TIMEOUT",
+  "CONFIG_TRANSACTION_ID",
   "CONFIG_UNSAFE_TLS",
   "CONFIG_WALLET_VERSION",
   "NODE_TLS_REJECT_UNAUTHORIZED",
@@ -139,6 +141,42 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
     expect(() => loadConfigWithHierarchy(null, DEFAULT_INI)).toThrow(
       /Configuration validation failed/,
     );
+  });
+
+  it("should map refresh_token_deferred from CONFIG_REFRESH_TOKEN_DEFERRED environment variable", () => {
+    process.env.CONFIG_REFRESH_TOKEN_DEFERRED = "my-deferred-refresh-token";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.issuance.refresh_token_deferred).toBe(
+      "my-deferred-refresh-token",
+    );
+  });
+
+  it("should map transaction_id from CONFIG_TRANSACTION_ID environment variable", () => {
+    process.env.CONFIG_TRANSACTION_ID = "deferred-txn-42";
+
+    const config = loadConfigWithHierarchy(null, DEFAULT_INI);
+
+    expect(config.issuance.transaction_id).toBe("deferred-txn-42");
+  });
+
+  it("should map refresh_token_deferred from direct CliOptions", () => {
+    const config = loadConfigWithHierarchy(
+      { refreshTokenDeferred: "cli-deferred-token" },
+      DEFAULT_INI,
+    );
+
+    expect(config.issuance.refresh_token_deferred).toBe("cli-deferred-token");
+  });
+
+  it("should map transaction_id from direct CliOptions", () => {
+    const config = loadConfigWithHierarchy(
+      { transactionId: "cli-txn-id" },
+      DEFAULT_INI,
+    );
+
+    expect(config.issuance.transaction_id).toBe("cli-txn-id");
   });
 });
 

--- a/tests/unit/config-loader.unit.spec.ts
+++ b/tests/unit/config-loader.unit.spec.ts
@@ -158,7 +158,7 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
 
     const config = loadConfigWithHierarchy(null, DEFAULT_INI);
 
-    expect(config.issuance.transaction_id).toBe("deferred-txn-42");
+    expect(config.issuance.transaction_id_deferred).toBe("deferred-txn-42");
   });
 
   it("should map refresh_token_deferred from direct CliOptions", () => {
@@ -176,7 +176,7 @@ describe("loadConfigWithHierarchy – environment overrides", () => {
       DEFAULT_INI,
     );
 
-    expect(config.issuance.transaction_id).toBe("cli-txn-id");
+    expect(config.issuance.transaction_id_deferred).toBe("cli-txn-id");
   });
 });
 

--- a/tests/unit/orchestrator-deferred.unit.spec.ts
+++ b/tests/unit/orchestrator-deferred.unit.spec.ts
@@ -195,7 +195,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
     // Reset deferred-flow fields to undefined after each new orchestrator
     // (the mock returns the same config object, so mutations bleed between tests)
     orchestrator.getConfig().issuance.refresh_token_deferred = undefined;
-    orchestrator.getConfig().issuance.transaction_id = undefined;
+    orchestrator.getConfig().issuance.transaction_id_deferred = undefined;
   });
 
   test("fails fast when both refresh_token_deferred and transaction_id are missing", async () => {
@@ -234,7 +234,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
   });
 
   test("fails fast when only transaction_id is set", async () => {
-    orchestrator.getConfig().issuance.transaction_id = "txn-123";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-123";
 
     const fetchSpy = vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -250,7 +250,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("does not call PAR or authorize steps", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -289,7 +289,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("token step receives grant_type=refresh_token with refresh_token_deferred value", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "my-deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -323,7 +323,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("deferred step is called with deferred_credential_endpoint and transaction_id", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-xyz";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-xyz";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -357,7 +357,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("deferred step receives the same dPoPKey from the token request", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -387,7 +387,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("returns success:true with deferredCredentialResponse on immediate (200) response", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -417,7 +417,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("returns success:true with deferredCredentialResponse on still-pending (202) response", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -445,7 +445,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("returns success:false with IssuerMetadataError when deferred_credential_endpoint is missing", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -468,7 +468,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("token failure returns partial response with fetchMetadataResponse", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -493,7 +493,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("deferred step failure returns partial response with tokenResponse", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing
@@ -524,7 +524,7 @@ describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
 
   test("never throws — error is always captured in result.error", async () => {
     orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
-    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+    orchestrator.getConfig().issuance.transaction_id_deferred = "txn-abc";
 
     vi.spyOn(
       // @ts-expect-error accessing private field for testing

--- a/tests/unit/orchestrator-deferred.unit.spec.ts
+++ b/tests/unit/orchestrator-deferred.unit.spec.ts
@@ -1,0 +1,540 @@
+/* eslint-disable max-lines-per-function */
+/**
+ * Unit tests for the Deferred Issuance Flow in WalletIssuanceOrchestratorFlow.
+ *
+ * Verifies that:
+ * - deferred() returns a typed unsuccessful result without calling remote steps
+ *   when either refresh_token_deferred or transaction_id is missing.
+ * - deferred() uses grant_type=refresh_token with the deferred refresh token.
+ * - deferred() posts to deferred_credential_endpoint with the transaction_id.
+ * - deferred() saves a credential when save_credential=true and the response is immediate.
+ * - deferred() returns partial responses on token / deferred-step failures.
+ * - deferred() returns success:true for a 202 still-pending response.
+ * - issuance() and reissuance() are unaffected by the new field.
+ */
+
+import { IssuerTestConfiguration } from "#/config/issuance-test-configuration";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { WalletIssuanceOrchestratorFlow } from "@/orchestrator/wallet-issuance-orchestrator-flow";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/logic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/logic")>();
+  return {
+    ...actual,
+    loadConfigWithHierarchy: vi.fn().mockReturnValue({
+      issuance: {
+        credential_offer_uri: "",
+        credential_types: ["dc_sd_jwt_PersonIdentificationData"],
+        save_credential: false,
+        url: "https://issuer.example.com",
+      },
+      logging: {
+        log_file: "",
+        log_file_format: "json",
+        log_format: "pretty",
+        log_level: "silent",
+      },
+      network: { max_retries: 1, timeout: 10, user_agent: "test" },
+      presentation: {
+        authorize_request_url:
+          "https://verifier.example.com/authorize?client_id=https://verifier.example.com",
+        verifier: "https://verifier.example.com",
+      },
+      steps_mapping: { mapping: {} },
+      trust: { trust_anchor_entity_configuration_url: "" },
+      trust_anchor: { port: 3000, ta_url: "http://localhost:3000" },
+      wallet: {
+        backup_storage_path: "./backup",
+        credentials_storage_path: "./credentials",
+        wallet_version: "1.0",
+      },
+    }),
+  };
+});
+
+vi.mock("@/functions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/functions")>();
+  return {
+    ...actual,
+    loadAttestation: vi.fn().mockResolvedValue({
+      attestation: "mock-attestation-jwt",
+      trustChain: [],
+      unitKey: {
+        privateKey: { crv: "P-256", d: "mock-d", kty: "EC" },
+        publicKey: {
+          crv: "P-256",
+          kid: "mock-kid",
+          kty: "EC",
+          x: "mock-x",
+          y: "mock-y",
+        },
+      },
+    }),
+    loadCredentialsForPresentation: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("@pagopa/io-wallet-oauth2", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@pagopa/io-wallet-oauth2")>();
+  return {
+    ...actual,
+    createClientAttestationPopJwt: vi
+      .fn()
+      .mockResolvedValue("mock-pop-attestation"),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStepFailure(message: string) {
+  return {
+    durationMs: 10,
+    error: new Error(message),
+    success: false as const,
+  };
+}
+
+function makeStepSuccess<T>(response: T) {
+  return { durationMs: 10, response, success: true as const };
+}
+
+const fetchMetadataSuccess = makeStepSuccess({
+  discoveredVia: "federation" as const,
+  entityStatementClaims: {
+    iss: "https://issuer.example.com",
+    metadata: {
+      oauth_authorization_server: {
+        authorization_endpoint: "https://issuer.example.com/authorize",
+        pushed_authorization_request_endpoint: "https://issuer.example.com/par",
+        token_endpoint: "https://issuer.example.com/token",
+      },
+      openid_credential_issuer: {
+        credential_configurations_supported: {
+          dc_sd_jwt_PersonIdentificationData: {},
+        },
+        credential_endpoint: "https://issuer.example.com/credential",
+        deferred_credential_endpoint:
+          "https://issuer.example.com/credential/deferred",
+        nonce_endpoint: "https://issuer.example.com/nonce",
+      },
+    },
+    sub: "https://issuer.example.com",
+  },
+  status: 200,
+});
+
+const fetchMetadataMissingDeferred = makeStepSuccess({
+  discoveredVia: "federation" as const,
+  entityStatementClaims: {
+    iss: "https://issuer.example.com",
+    metadata: {
+      oauth_authorization_server: {
+        token_endpoint: "https://issuer.example.com/token",
+      },
+      openid_credential_issuer: {
+        credential_configurations_supported: {
+          dc_sd_jwt_PersonIdentificationData: {},
+        },
+        credential_endpoint: "https://issuer.example.com/credential",
+        nonce_endpoint: "https://issuer.example.com/nonce",
+      },
+    },
+    sub: "https://issuer.example.com",
+  },
+  status: 200,
+});
+
+const dPoPKey = {
+  privateKey: { crv: "P-256", d: "mock-d", kty: "EC" },
+  publicKey: {
+    crv: "P-256",
+    kid: "mock-kid",
+    kty: "EC",
+    x: "mock-x",
+    y: "mock-y",
+  },
+};
+
+const tokenSuccess = makeStepSuccess({
+  access_token: "mock-access-token",
+  dPoPKey,
+});
+
+// 200 immediate deferred response with credentials
+const deferredSuccessImmediate = makeStepSuccess({
+  credentials: [{ credential: "mock-deferred-credential" }],
+  notification_id: "mock-notif",
+});
+
+// 202 still-pending response
+const deferredSuccessPending = makeStepSuccess({
+  interval: 5,
+  transaction_id: "new-txn-id",
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WalletIssuanceOrchestratorFlow.deferred()", () => {
+  let orchestrator: WalletIssuanceOrchestratorFlow;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new WalletIssuanceOrchestratorFlow(
+      IssuerTestConfiguration.createDefault(),
+    );
+    // Reset deferred-flow fields to undefined after each new orchestrator
+    // (the mock returns the same config object, so mutations bleed between tests)
+    orchestrator.getConfig().issuance.refresh_token_deferred = undefined;
+    orchestrator.getConfig().issuance.transaction_id = undefined;
+  });
+
+  test("fails fast when both refresh_token_deferred and transaction_id are missing", async () => {
+    const fetchSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    );
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain(
+      "Deferred Issuance Flow requires both a deferred refresh token and a transaction id",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("fails fast when only refresh_token_deferred is set", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred =
+      "my-deferred-token";
+
+    const fetchSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    );
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain(
+      "deferred refresh token and a transaction id",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("fails fast when only transaction_id is set", async () => {
+    orchestrator.getConfig().issuance.transaction_id = "txn-123";
+
+    const fetchSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    );
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not call PAR or authorize steps", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.deferredCredentialRequestStep,
+      "run",
+    ).mockResolvedValue(deferredSuccessImmediate as never);
+
+    const parSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.pushedAuthorizationRequestStep,
+      "run",
+    );
+    const authorizeSpy = vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.authorizeStep,
+      "run",
+    );
+
+    await orchestrator.deferred();
+
+    expect(parSpy).not.toHaveBeenCalled();
+    expect(authorizeSpy).not.toHaveBeenCalled();
+  });
+
+  test("token step receives grant_type=refresh_token with refresh_token_deferred value", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "my-deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    const tokenRunSpy = vi
+      .spyOn(
+        // @ts-expect-error accessing private field for testing
+        orchestrator.tokenRequestStep,
+        "run",
+      )
+      .mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.deferredCredentialRequestStep,
+      "run",
+    ).mockResolvedValue(deferredSuccessImmediate as never);
+
+    await orchestrator.deferred();
+
+    expect(tokenRunSpy).toHaveBeenCalledOnce();
+    const tokenCallArg = tokenRunSpy.mock.calls[0]?.[0];
+    expect(tokenCallArg?.accessTokenRequest).toMatchObject({
+      grant_type: "refresh_token",
+      refresh_token: "my-deferred-rt",
+    });
+  });
+
+  test("deferred step is called with deferred_credential_endpoint and transaction_id", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-xyz";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    const deferredSpy = vi
+      .spyOn(
+        // @ts-expect-error accessing private field for testing
+        orchestrator.deferredCredentialRequestStep,
+        "run",
+      )
+      .mockResolvedValue(deferredSuccessImmediate as never);
+
+    await orchestrator.deferred();
+
+    expect(deferredSpy).toHaveBeenCalledOnce();
+    const deferredCallArg = deferredSpy.mock.calls[0]?.[0];
+    expect(deferredCallArg?.deferredCredentialEndpoint).toBe(
+      "https://issuer.example.com/credential/deferred",
+    );
+    expect(deferredCallArg?.transactionId).toBe("txn-xyz");
+  });
+
+  test("deferred step receives the same dPoPKey from the token request", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    const deferredSpy = vi
+      .spyOn(
+        // @ts-expect-error accessing private field for testing
+        orchestrator.deferredCredentialRequestStep,
+        "run",
+      )
+      .mockResolvedValue(deferredSuccessImmediate as never);
+
+    await orchestrator.deferred();
+
+    const deferredCallArg = deferredSpy.mock.calls[0]?.[0];
+    expect(deferredCallArg?.dPoPKey).toEqual(dPoPKey);
+  });
+
+  test("returns success:true with deferredCredentialResponse on immediate (200) response", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.deferredCredentialRequestStep,
+      "run",
+    ).mockResolvedValue(deferredSuccessImmediate as never);
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(true);
+    expect(result.deferredCredentialResponse).toEqual(deferredSuccessImmediate);
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toEqual(tokenSuccess);
+  });
+
+  test("returns success:true with deferredCredentialResponse on still-pending (202) response", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.deferredCredentialRequestStep,
+      "run",
+    ).mockResolvedValue(deferredSuccessPending as never);
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(true);
+    expect(result.deferredCredentialResponse).toEqual(deferredSuccessPending);
+  });
+
+  test("returns success:false with IssuerMetadataError when deferred_credential_endpoint is missing", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataMissingDeferred);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain("deferred_credential_endpoint");
+    expect(result.error?.message).toContain("openid_credential_issuer");
+  });
+
+  test("token failure returns partial response with fetchMetadataResponse", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(makeStepFailure("token endpoint returned 401"));
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("token endpoint returned 401");
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toBeDefined();
+    expect(result.deferredCredentialResponse).toBeUndefined();
+  });
+
+  test("deferred step failure returns partial response with tokenResponse", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockResolvedValue(fetchMetadataSuccess);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.tokenRequestStep,
+      "run",
+    ).mockResolvedValue(tokenSuccess as never);
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.deferredCredentialRequestStep,
+      "run",
+    ).mockResolvedValue(makeStepFailure("deferred endpoint returned 400"));
+
+    const result = await orchestrator.deferred();
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("deferred endpoint returned 400");
+    expect(result.fetchMetadataResponse).toEqual(fetchMetadataSuccess);
+    expect(result.tokenResponse).toEqual(tokenSuccess);
+    expect(result.deferredCredentialResponse).toBeDefined();
+  });
+
+  test("never throws — error is always captured in result.error", async () => {
+    orchestrator.getConfig().issuance.refresh_token_deferred = "deferred-rt";
+    orchestrator.getConfig().issuance.transaction_id = "txn-abc";
+
+    vi.spyOn(
+      // @ts-expect-error accessing private field for testing
+      orchestrator.fetchMetadataStep,
+      "run",
+    ).mockRejectedValue(new Error("unexpected network error"));
+
+    await expect(orchestrator.deferred()).resolves.toMatchObject({
+      error: expect.objectContaining({ message: "unexpected network error" }),
+      success: false,
+    });
+  });
+});


### PR DESCRIPTION
#### Motivation and Context

Implementing support for the Deferred Issuance Flow addresses the need for testing credential requests that require a deferred refresh token and transaction ID. This change enhances the issuance process by allowing users to test credentials from a deferred endpoint.


- Added support for Deferred Issuance Flow with new CLI options and configuration mappings.

- Implemented error handling and unit tests for the Deferred Issuance Flow.

- Enhanced tests for Deferred Endpoint Issuance with fetch metadata assertions.

- Introduced new error classes to manage precondition failures in the issuance flow.


#### How Has This Been Tested?



Changes have been thoroughly tested with unit tests covering the new Deferred Issuance Flow, including error handling and assertion helpers. The testing environment includes various configurations to ensure compatibility and correctness of the new features.


