### PR TITLE
chore: Skip Trust Anchor verification option in CLI

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -72,13 +72,17 @@ user_agent = CEN-TC-Wallet-CLI/1.0.0
 # tls_reject_unauthorized = false
 
 [trust_anchor]
-# Trust Anchor Server Configuration
+# Local Trust Anchor Server Configuration
 port = 3001
 
-# Trust Anchor Server Certificates dir
+# Local Trust Anchor Server Certificates dir
 # Directory that contains the certificates for the trust anchor's HTTPS server.
 # Expected filenames: server.cert.pem and server.key.pem (auto-generated if absent).
 tls_cert_dir = ./data/backup
+
+# Set to false to skip tests that require Trust Anchor verification (CI_003, CI_004, RPR-10).
+# This is useful when the External Trust Anchor is not reachable or federation verification is not needed.
+# verify = true
 
 [logging]
 # Logging Configuration

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,6 +133,9 @@ function setEnvFromOptions(options: CliOptions): NodeJS.ProcessEnv {
   if (options.unsafeTls) {
     env.CONFIG_UNSAFE_TLS = "true";
   }
+  if (options.trustAnchorVerify !== undefined) {
+    env.CONFIG_TRUST_ANCHOR_VERIFY = options.trustAnchorVerify.toString();
+  }
   if (options.tests) {
     env.TESTS = options.tests;
   }
@@ -213,6 +216,11 @@ function addCommonOptions(command: Command): Command {
     .option(
       "--unsafe-tls",
       "Disable TLS certificate verification (for local self-signed certs). Sets tls_reject_unauthorized=false (env: CONFIG_UNSAFE_TLS).",
+    )
+    .option(
+      "--trust-anchor-verify <bool>",
+      "Set to false to skip tests that require Trust Anchor verification (CI_003, CI_004, RPR-10). Defaults to true (env: CONFIG_TRUST_ANCHOR_VERIFY).",
+      (val) => val !== "false",
     )
     .option(
       "--tests <names>",

--- a/src/logic/config-loader.ts
+++ b/src/logic/config-loader.ts
@@ -39,6 +39,7 @@ export interface CliOptions {
   tests?: string;
   timeout?: number;
   trustAnchorCertDir?: string;
+  trustAnchorVerify?: boolean;
   unsafeTls?: boolean;
 }
 
@@ -389,6 +390,9 @@ const buildTrustAnchorConfig: ConfigSectionBuilder<Config["trust_anchor"]> = (
   ...(options.trustAnchorCertDir !== undefined && {
     tls_cert_dir: options.trustAnchorCertDir,
   }),
+  ...(options.trustAnchorVerify !== undefined && {
+    verify: options.trustAnchorVerify,
+  }),
 });
 
 function buildStepsMappingConfig(
@@ -504,6 +508,7 @@ function readCliOptionsFromEnv(): CliOptions {
   readStringEnv(options, "stepsMapping", "CONFIG_STEPS_MAPPING");
   readBooleanEnv(options, "unsafeTls", "CONFIG_UNSAFE_TLS");
   readStringEnv(options, "trustAnchorCertDir", "CONFIG_TRUST_ANCHOR_CERT_DIR");
+  readBooleanEnv(options, "trustAnchorVerify", "CONFIG_TRUST_ANCHOR_VERIFY");
   readStringEnv(options, "bindAddress", "OIDF_SERVERS_BIND_ADDRESS");
 
   return options;

--- a/src/logic/jwk.ts
+++ b/src/logic/jwk.ts
@@ -1,5 +1,10 @@
-import { Jwk, type JwtSigner } from "@pagopa/io-wallet-oauth2";
 import {
+  Jwk,
+  type JwtSigner,
+  VerifyJwtCallback,
+} from "@pagopa/io-wallet-oauth2";
+import {
+  fetchAndValidateTrustChain,
   jsonWebKeySchema,
   jsonWebKeySetSchema,
 } from "@pagopa/io-wallet-oid-federation";
@@ -17,7 +22,7 @@ import { writeFileSync } from "node:fs";
 import { KeyPair, KeyPairJwk } from "@/types";
 
 import { loadCertificate } from "./pem";
-import { buildCertPath } from "./utils";
+import { buildCertPath, partialCallbacks } from "./utils";
 
 /**
  * Generates a new cryptographic key pair (ECDSA with P-256 curve) and saves it to a file.
@@ -95,7 +100,10 @@ export async function createKeys(): Promise<KeyPair> {
  * @returns The extracted public JWK.
  * @throws An error if the signer method is not supported.
  */
-export async function jwkFromSigner(signer: JwtSigner): Promise<Jwk> {
+export async function jwkFromSigner(
+  signer: JwtSigner,
+  payload?: Parameters<VerifyJwtCallback>[1]["payload"],
+): Promise<Jwk> {
   const { didUrl, kid, trustChain } = signer as {
     didUrl?: string;
     kid?: string;
@@ -118,10 +126,7 @@ export async function jwkFromSigner(signer: JwtSigner): Promise<Jwk> {
       );
     case "federation":
       if (!kid) throw new Error("missing signer key's kid");
-      if (!trustChain || !trustChain.length) {
-        throw new Error("missing signer's trust chain");
-      }
-      return await jwkFromTrustChain(trustChain, kid);
+      return await jwkFromFederation(kid, trustChain, payload);
     case "jwk":
       return parseWithErrorHandling(
         jsonWebKeySchema,
@@ -206,11 +211,22 @@ async function jwkFromCertificateChain(
  * @throws An error if the trust chain is empty, the entity config signature is invalid,
  *         or the key is not found.
  */
-async function jwkFromTrustChain(
-  trustChain: string[],
+async function jwkFromFederation(
   signerKid: string,
+  trustChain?: string[],
+  payload?: Parameters<VerifyJwtCallback>[1]["payload"],
 ): Promise<Jwk> {
-  const entityConfigurationJwt = trustChain[0];
+  const ecTrustChain =
+    trustChain ??
+    (await (() => {
+      if (!payload?.iss) throw new Error("missing iss in payload");
+      return fetchAndValidateTrustChain(payload.iss, {
+        callbacks: {
+          ...partialCallbacks,
+        },
+      });
+    })());
+  const entityConfigurationJwt = ecTrustChain ? ecTrustChain[0] : undefined;
   if (!entityConfigurationJwt) throw new Error("empty trust chain");
 
   const keys: Jwk[] = [];

--- a/src/logic/jwt.ts
+++ b/src/logic/jwt.ts
@@ -19,7 +19,7 @@ import { jwkFromSigner } from "./jwk";
  */
 export function signJwtCallback(privateJwks: JWK[]): SignJwtCallback {
   return async (signer, { header, payload }) => {
-    const publicJwk = await jwkFromSigner(signer);
+    const publicJwk = await jwkFromSigner(signer, payload);
     const privateJwk = privateJwks.find(
       (jwkPrv) => jwkPrv.kid === publicJwk.kid,
     );
@@ -76,7 +76,7 @@ export const signCallback: SignCallback = async ({ jwk, toBeSigned }) => {
 export const verifyJwt: VerifyJwtCallback = async (signer, jwt) => {
   let publicJwk: Jwk;
   try {
-    publicJwk = await jwkFromSigner(signer);
+    publicJwk = await jwkFromSigner(signer, jwt.payload);
   } catch {
     return { verified: false };
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -76,6 +76,7 @@ export const configSchema = z.object({
   trust_anchor: z.object({
     port: z.coerce.number(),
     tls_cert_dir: z.string().optional(),
+    verify: zBooleanFromString.optional().default(true),
   }),
   wallet: z.object({
     backup_storage_path: z.string(),

--- a/tests/conformance/issuance/happy.issuance.spec.ts
+++ b/tests/conformance/issuance/happy.issuance.spec.ts
@@ -52,6 +52,8 @@ testConfigs.forEach((testConfig) => {
     const sdkConfig = new IoWalletSdkConfig({
       itWalletSpecsVersion: orchestrator.getConfig().wallet.wallet_version,
     });
+    const shouldSkipTrustAnchorVerification =
+      orchestrator.getConfig().trust_anchor.verify === false;
 
     beforeAll(async () => {
       try {
@@ -128,36 +130,48 @@ testConfigs.forEach((testConfig) => {
       }
     });
 
-    test("CI_003: Fetch Metadata | The Entity Configuration is cryptographically signed", async () => {
-      const log = baseLog.withTag("CI_003");
-      const DESCRIPTION = "Entity Configuration is cryptographically signed";
+    test(
+      "CI_003: Fetch Metadata | The Entity Configuration is cryptographically signed",
+      { skip: shouldSkipTrustAnchorVerification },
+      async () => {
+        const log = baseLog.withTag("CI_003");
+        const DESCRIPTION = "Entity Configuration is cryptographically signed";
 
-      log.start(
-        "Conformance test: Verifying Entity Configuration JWT signature",
-      );
+        log.start(
+          "Conformance test: Verifying Entity Configuration JWT signature",
+        );
 
-      let testSuccess = false;
-      try {
-        log.debug("→ Validating response is present...");
-        expect(fetchMetadataResponse.response).toBeDefined();
+        let testSuccess = false;
+        try {
+          const config = orchestrator.getConfig();
+          const { credentialIssuer } =
+            await orchestrator.findCredentialConfig();
+          const entityClaims = await fetchMetadata({
+            callbacks: {
+              fetch: fetchWithConfig(config.network),
+              verifyJwt,
+            },
+            config: new IoWalletSdkConfig({
+              itWalletSpecsVersion: config.wallet.wallet_version,
+            }),
+            credentialIssuerUrl: credentialIssuer,
+          });
 
-        log.debug("→ Asserting response status...");
-        expect(fetchMetadataResponse.response?.status).toBe(200);
+          log.debug("→ Checking Entity Statement JWT is present...");
+          expect(entityClaims).toBeDefined();
 
-        log.debug("→ Checking Entity Statement JWT is present...");
-        expect(
-          fetchMetadataResponse.response?.discoveredVia === "federation",
-        ).toBeTruthy();
-
-        testSuccess = true;
-      } finally {
-        log.testCompleted(DESCRIPTION, testSuccess);
-      }
-    });
+          testSuccess = true;
+        } catch (e) {
+          log.error("Error fetching metadata:", e);
+        } finally {
+          log.testCompleted(DESCRIPTION, testSuccess);
+        }
+      },
+    );
 
     test(
       "CI_004: Fetch Metadata | Public Key inclusion in Entity Configuration and Subordinate Statement",
-      { skip: process.env.CI === "true" },
+      { skip: shouldSkipTrustAnchorVerification },
       async () => {
         const log = baseLog.withTag("CI_004");
         const DESCRIPTION =
@@ -270,7 +284,7 @@ testConfigs.forEach((testConfig) => {
             metadata: z.any(),
             sub: z.string(),
           })
-          .passthrough()
+          .loose()
           .refine((data) => data.metadata !== undefined, {
             message: "metadata is missing",
           })
@@ -301,25 +315,14 @@ testConfigs.forEach((testConfig) => {
 
         let testSuccess = false;
         try {
-          const config = orchestrator.getConfig();
-          const { credentialIssuer } =
-            await orchestrator.findCredentialConfig();
-          const entityClaims = await fetchMetadata({
-            callbacks: {
-              fetch: fetchWithConfig(config.network),
-              verifyJwt,
-            },
-            config: new IoWalletSdkConfig({
-              itWalletSpecsVersion: config.wallet.wallet_version,
-            }),
-            credentialIssuerUrl: credentialIssuer,
-          });
+          const entityClaims =
+            fetchMetadataResponse.response?.entityStatementClaims;
 
           const result = z
             .object({
               metadata: z.any(),
             })
-            .passthrough()
+            .loose()
             .refine(
               (data) =>
                 data.metadata !== undefined &&
@@ -362,7 +365,7 @@ testConfigs.forEach((testConfig) => {
           .object({
             metadata: z.any(),
           })
-          .passthrough()
+          .loose()
           .refine(
             (data) =>
               data.metadata !== undefined &&

--- a/tests/conformance/presentation/happy.presentation.spec.ts
+++ b/tests/conformance/presentation/happy.presentation.spec.ts
@@ -21,6 +21,8 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
   const orchestrator: WalletPresentationOrchestratorFlow =
     new WalletPresentationOrchestratorFlow(testConfig);
   const baseLog = orchestrator.getLog();
+  const shouldSkipTrustAnchorVerification =
+    orchestrator.getConfig().trust_anchor.verify === false;
 
   let authorizationRequestResult: AuthorizationRequestStepResponse;
   let fetchMetadataResult: FetchMetadataVpStepResponse;
@@ -148,7 +150,7 @@ describe(`[${testConfig.name}] Credential Presentation Tests`, () => {
 
   test(
     "RPR-10: Authorization request parameters match OpenID Credential Verifier metadata.",
-    { skip: process.env.CI === "true" },
+    { skip: shouldSkipTrustAnchorVerification },
     async ({ skip }) => {
       const log = baseLog.withTag("RPR010");
 


### PR DESCRIPTION
#### Motivation and Context

This change introduces an option to skip Trust Anchor verification in the CLI and configuration, addressing scenarios where the External Trust Anchor is unreachable or federation verification is not necessary.

#### How Has This Been Tested?

Changes have been tested by adding new options in the CLI and updating relevant tests to conditionally skip Trust Anchor verification based on the new configuration. The implementation has been validated in the testing environment to ensure it does not disrupt existing functionality.

